### PR TITLE
Update to recipe for CMSSW 90X

### DIFF
--- a/HGCalAnalysis/plugins/BuildFile.xml
+++ b/HGCalAnalysis/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="RecoNtuples/HGCalAnalysis"/>
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/CaloAnalysis"/>
+<use   name="CommonTools/UtilAlgos"/>
 <library   file="*.cc" name="RecoNtuplesHGCalAnalysisPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -422,14 +422,14 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       cluster_index++;
     }
 
-    double pt = multiClusters[i].total_uncalibrated_energy() / cosh(multiClusters[i].simple_eta(vz));
-    amcc->push_back(AMultiCluster(multiClusters[i].simple_eta(vz),
-				  multiClusters[i].simple_phi(),
-                  pt,
-				  multiClusters[i].simple_z(vz),
-				  multiClusters[i].simple_slope_x(vz),
-				  multiClusters[i].simple_slope_y(vz),
-				  multiClusters[i].total_uncalibrated_energy(),
+    double pt = multiClusters[i].energy() / cosh(multiClusters[i].eta());
+    amcc->push_back(AMultiCluster(multiClusters[i].eta(),
+				  multiClusters[i].phi(),
+                                  pt,
+				  multiClusters[i].z(),
+				  multiClusters[i].x(),
+				  multiClusters[i].y(),
+                                  multiClusters[i].energy(),
 				  multiClusters[i].size(),
 				  cl2dSeed));
   }

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -37,7 +37,6 @@
 
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h"
-#include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalMultiCluster.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 #include "RecoNtuples/HGCalAnalysis/interface/AEvent.h"
@@ -73,6 +72,7 @@ private:
   edm::EDGetTokenT<std::vector<SimCluster> > _simClusters;
   edm::EDGetTokenT<std::vector<reco::PFCluster> > _pfClusters;
   edm::EDGetTokenT<std::vector<CaloParticle> > _caloParticles;
+  edm::EDGetTokenT<std::vector<reco::HGCalMultiCluster> > _multiClusters;
 
   TTree                     *tree;
   AEvent                    *event;
@@ -95,7 +95,6 @@ private:
 
 HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
   detector(iConfig.getParameter<std::string >("detector")),
-  pre(iConfig.getParameter<double>("depthClusteringCone")),
   rawRecHits(iConfig.getParameter<bool>("rawRecHits"))
 {
   //now do what ever initialization is needed
@@ -115,13 +114,13 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
     _recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
     algo = 3;
   }
-  //_clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("imagingClusterHGCal"));
   _clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
   _vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
   _part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
   _simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
   _pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
   _caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
+  _multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
 
   edm::Service<TFileService> fs;
   fs->make<TH1F>("total", "total", 100, 0, 5.);
@@ -186,7 +185,6 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   Handle<HGCRecHitCollection> recHitHandleBH;
   Handle<reco::CaloClusterCollection> clusterHandle;
 
-  std::vector<HGCalMultiCluster> multiClusters;
   iEvent.getByToken(_clusters,clusterHandle);
   Handle<std::vector<TrackingVertex> > vtxHandle;
   Handle<std::vector<TrackingParticle> > partHandle;
@@ -206,6 +204,10 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   const std::vector<SimCluster>& simClusters = *simClusterHandle;
   const std::vector<reco::PFCluster>& pfClusters = *pfClusterHandle;
   const std::vector<CaloParticle>& caloParticles = *caloParticleHandle;
+
+  Handle<std::vector<reco::HGCalMultiCluster> > multiClusterHandle;
+  iEvent.getByToken(_multiClusters, multiClusterHandle);
+  const std::vector<reco::HGCalMultiCluster>& multiClusters = *multiClusterHandle;
 
   float vx = 0.;
   float vy = 0.;
@@ -367,16 +369,15 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   const reco::CaloClusterCollection &clusters = *clusterHandle;
   nclus = clusters.size();
-  multiClusters = pre.makePreClusters(clusters);
   nmclus = multiClusters.size();
   unsigned int cluster_index = 0;
   for(unsigned int i = 0; i < multiClusters.size(); i++){
       int cl2dSeed = 0;
-    for(HGCalMultiCluster::component_iterator it = multiClusters[i].begin();
+    for(reco::HGCalMultiCluster::component_iterator it = multiClusters[i].begin();
 	it!=multiClusters[i].end(); it++){
-      if(it->energy() > (it+cl2dSeed)->energy()) cl2dSeed = it - multiClusters[i].begin();
+      if((*it)->energy() > (*(it+cl2dSeed))->energy()) cl2dSeed = it - multiClusters[i].begin();
 
-      const std::vector< std::pair<DetId, float> > &hf = it->hitsAndFractions();
+      const std::vector< std::pair<DetId, float> > &hf = (*it)->hitsAndFractions();
       int ncoreHit = 0;
       int layer = 0;
       int rhSeed = 0;
@@ -414,9 +415,9 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
                 isHalfCell, flags, cluster_index));
 
       }
-      double pt = it->energy() / cosh(it->eta());
-      acdc->push_back(ACluster2d(it->x(),it->y(),it->z(),
-				 it->eta(),it->phi(),pt,it->energy(),
+      double pt = (*it)->energy() / cosh((*it)->eta());
+      acdc->push_back(ACluster2d((*it)->x(),(*it)->y(),(*it)->z(),
+				 (*it)->eta(),(*it)->phi(),pt,(*it)->energy(),
 				 layer, ncoreHit,hf.size(),i, rhSeed));
       cluster_index++;
     }

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -115,7 +115,8 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
     _recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
     algo = 3;
   }
-  _clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("imagingClusterHGCal"));
+  //_clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("imagingClusterHGCal"));
+  _clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
   _vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
   _part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
   _simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -36,8 +36,8 @@
 
 
 
-#include "RecoLocalCalo/HGCalRecHitDump/interface/HGCalDepthPreClusterer.h"
-#include "RecoLocalCalo/HGCalRecHitDump/interface/HGCalMultiCluster.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalMultiCluster.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 #include "RecoNtuples/HGCalAnalysis/interface/AEvent.h"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-based on CMSSW_9_0_X:
+This temporary version is based on CMSSW_9_0_X. Once github.com/cms-sw/cmssw/pull/16997 is merged, we can use a prerelease and the setup will be cleaner.
 
 ```
 cmsrel CMSSW_9_0_X_2016-12-07-2300
@@ -11,6 +11,9 @@ cd CMSSW_9_0_X_2016-12-07-2300/src
 cmsenv
 git cms-merge-topic lgray:hgcal_cluster_speed
 git cms-merge-topic edjtscott:hgcal_multiclustering_realspacecone
+git checkout --theirs RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
+git add -u 
+git commit -m "conflict fixed"
 git checkout -b topic_${USER}
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 scram b -j9

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-to be added on top of CMS-HGCAL:hgcal_clustering_development_810, based on CMSSW_8_1_0_pre15:
+based on CMSSW_9_0_0_pre2:
 
 ```
-cmsrel CMSSW_8_1_0_pre15
-cd CMSSW_8_1_0_pre15/src
+cmsrel CMSSW_9_0_0_pre2
+cd CMSSW_9_0_0_pre2/src
 cmsenv
-git cms-merge-topic CMS-HGCAL:hgcal_clustering_development_810
-git checkout CMS-HGCAL/hgcal_clustering_development_810
+git cms-merge-topic lgray:hgcal_cluster_speed
+git cms-merge-topic edjtscott:hgcal_multiclustering_realspacecone
 git checkout -b topic_${USER}
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 scram b -j9

--- a/README.md
+++ b/README.md
@@ -3,17 +3,13 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-This temporary version is based on CMSSW_9_0_X. Once github.com/cms-sw/cmssw/pull/16997 is merged, we can use a prerelease and the setup will be cleaner.
+This version is based on CMSSW_9_0_X. Further updates to the recipe will occur once github.com/cms-sw/cmssw/pull/16997 is merged into CMSSW.
 
 ```
-cmsrel CMSSW_9_0_X_2016-12-07-2300
-cd CMSSW_9_0_X_2016-12-07-2300/src
+cmsrel CMSSW_9_0_0_pre2
+cd CMSSW_9_0_pre2/src
 cmsenv
-git cms-merge-topic lgray:hgcal_cluster_speed
 git cms-merge-topic edjtscott:hgcal_multiclustering_realspacecone
-git checkout --theirs RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
-git add -u 
-git commit -m "conflict fixed"
 git checkout -b topic_${USER}
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 scram b -j9

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-based on CMSSW_9_0_0_pre2:
+based on CMSSW_9_0_X:
 
 ```
-cmsrel CMSSW_9_0_0_pre2
-cd CMSSW_9_0_0_pre2/src
+cmsrel CMSSW_9_0_X_2016-12-07-2300
+cd CMSSW_9_0_X_2016-12-07-2300/src
 cmsenv
 git cms-merge-topic lgray:hgcal_cluster_speed
 git cms-merge-topic edjtscott:hgcal_multiclustering_realspacecone


### PR DESCRIPTION
These two PRs have the necessary changes for the various rearrangements and improvements that Lindsey has made to the HGCal code, most of which is now included in CMSSW release 9_0_0_pre2. The main changes are:

-  Both the 2D clustering and multiclustering are now run by default in the reconstruction step, and the name of the module has become hgcalLayerClusters
-  The bug in the clustering associated with the use of pointers has been fixed
-  The HGCal has moved from D3 to D4 in CMSSW version 9
-  An option to do the multiclustering in real space (a bool called realSpaceCone) has been added

I've tested the full workflow (GSD, RECO, NTUP steps) for photons with pT=35 GeV and the usual validation plots are [here](http://escott.web.cern.ch/escott/HGCclustering/Pass6/Photon_Pt35/Unconverted/RebasedPre2fullTest/?match=SingleMC)