### PR TITLE
Reading official Reco; adding information (including extrapolations) to the GenParticles ; modified the storage of layer clusters

### DIFF
--- a/HGCalAnalysis/interface/AObData.h
+++ b/HGCalAnalysis/interface/AObData.h
@@ -2,20 +2,27 @@
 #define aobdata_h
 
 #include "TObject.h"
+#include <vector>
 
 class AGenPart : public TObject
 {
 public:
 
-  AGenPart(): eta(-1000.),phi(-1000.),pt(-1000.),energy(-1000.),dvx(0.),dvy(0.),dvz(0.),pid(0)
+ AGenPart(): eta(-1000.),phi(-1000.),pt(-1000.),energy(-1000.),dvx(0.),dvy(0.),dvz(0.),pid(0),gen(-1)
   {
   }
   AGenPart(float i_eta, float i_phi, float i_pt, float i_energy,
-	   float i_dvx, float i_dvy,float i_dvz, int i_pid) :
-    eta(i_eta),phi(i_phi),pt(i_pt),energy(i_energy),dvx(i_dvx),dvy(i_dvy),dvz(i_dvz),pid(i_pid)
+	   float i_dvx, float i_dvy,float i_dvz, int i_pid,int i_gen=-1) :
+  eta(i_eta),phi(i_phi),pt(i_pt),energy(i_energy),dvx(i_dvx),dvy(i_dvy),dvz(i_dvz),pid(i_pid),gen(i_gen)
   {
   }
 
+  inline void setExtrapolations(const std::vector<float>&x,const std::vector<float>& y,const std::vector<float>& z) 
+  {
+    posx=x;
+    posy=y;
+    posz=z;
+  }
   float eta;
   float phi;
   float pt;
@@ -24,8 +31,11 @@ public:
   float dvy;
   float dvz;
   int pid;
-
-  ClassDef(AGenPart,1)
+  int gen;
+  std::vector<float> posx;
+  std::vector<float> posy;
+  std::vector<float> posz;
+  ClassDef(AGenPart,1)      
 };
 
 

--- a/HGCalAnalysis/interface/AObData.h
+++ b/HGCalAnalysis/interface/AObData.h
@@ -8,12 +8,12 @@ class AGenPart : public TObject
 {
 public:
 
- AGenPart(): eta(-1000.),phi(-1000.),pt(-1000.),energy(-1000.),dvx(0.),dvy(0.),dvz(0.),pid(0),gen(-1)
+ AGenPart(): eta(-1000.),phi(-1000.),pt(-1000.),energy(-1000.),dvx(0.),dvy(0.),dvz(0.),pid(0),gen(-1),reachedEE(-1)
   {
   }
   AGenPart(float i_eta, float i_phi, float i_pt, float i_energy,
-	   float i_dvx, float i_dvy,float i_dvz, int i_pid,int i_gen=-1) :
-  eta(i_eta),phi(i_phi),pt(i_pt),energy(i_energy),dvx(i_dvx),dvy(i_dvy),dvz(i_dvz),pid(i_pid),gen(i_gen)
+	   float i_dvx, float i_dvy,float i_dvz, int i_pid,int i_gen=-1,int i_reachedEE=-1) :
+  eta(i_eta),phi(i_phi),pt(i_pt),energy(i_energy),dvx(i_dvx),dvy(i_dvy),dvz(i_dvz),pid(i_pid),gen(i_gen),reachedEE(i_reachedEE)
   {
   }
 
@@ -32,6 +32,7 @@ public:
   float dvz;
   int pid;
   int gen;
+  int reachedEE;
   std::vector<float> posx;
   std::vector<float> posy;
   std::vector<float> posz;

--- a/HGCalAnalysis/plugins/BuildFile.xml
+++ b/HGCalAnalysis/plugins/BuildFile.xml
@@ -3,11 +3,13 @@
 <use   name="Geometry/HGCalGeometry"/>
 <use   name="DataFormats/CaloRecHit"/>
 <use   name="DataFormats/ParticleFlowReco"/>
-<use   name="RecoLocalCalo/HGCalRecHitDump"/>
 <use   name="RecoNtuples/HGCalAnalysis"/>
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/CaloAnalysis"/>
 <use   name="CommonTools/UtilAlgos"/>
+<use   name="FastSimulation/Event"/>
+<use   name="hepmc"/>
+<use   name="heppdt"/>
 <library   file="*.cc" name="RecoNtuplesHGCalAnalysisPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -307,10 +307,10 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       npart = mySimEvent->nTracks();
       for (unsigned int i=0;i<npart ; ++i) {
 	std::vector<float> xp,yp,zp;
-	FSimTrack &myTrack = mySimEvent->track(i);
+	FSimTrack &myTrack(mySimEvent->track(i));
 	math::XYZTLorentzVectorD vtx(0,0,0,0);
-//	if(!myTrack.noMother())
-//	  std::cout << myTrack << std::endl;
+
+	int reachedEE=0;
 	if(!myTrack.noEndVertex()) 
 	  {
 	    vtx = myTrack.endVertex().position();	    
@@ -318,20 +318,21 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	else   
 	  {
 	    // went up to calorimeter: propagate it 
+	    reachedEE=1;
 	    RawParticle part(myTrack.momentum(),myTrack.vertex().position());
 	    part.setID(myTrack.id());
 	    BaseParticlePropagator myPropag(part,140,layerPositions[0],3.8);
 	    myPropag.propagate(); 	    
 	    vtx=myPropag.vertex();
 	    for(unsigned il=0;il<28;++il) {
-	      myPropag.setPropagationConditions(140,layerPositions[il]);
+	      myPropag.setPropagationConditions(140,layerPositions[il],false);
 	      myPropag.propagate();
 	      xp.push_back(myPropag.vertex().x());
 	      yp.push_back(myPropag.vertex().y());
 	      zp.push_back(myPropag.vertex().z());
 	    }
 	  }
-	AGenPart part(myTrack.momentum().eta(),myTrack.momentum().phi(),myTrack.momentum().pt(),myTrack.momentum().energy(),vtx.x(),vtx.y(),vtx.z(),myTrack.type(),myTrack.genpartIndex());
+	AGenPart part(myTrack.momentum().eta(),myTrack.momentum().phi(),myTrack.momentum().pt(),myTrack.momentum().energy(),vtx.x(),vtx.y(),vtx.z(),myTrack.type(),myTrack.genpartIndex(),reachedEE);
 	part.setExtrapolations(xp,yp,zp);
 	agpc->push_back(part);
       }

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -8,8 +8,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
-
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -20,6 +18,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -27,7 +26,10 @@
 #include "Geometry/CaloGeometry/interface/TruncatedPyramid.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-
+#include "FastSimulation/Event/interface/FSimEvent.h"
+#include "FastSimulation/Event/interface/FSimTrack.h"
+#include "FastSimulation/Event/interface/FSimVertex.h"
+#include "FastSimulation/Particle/interface/ParticleTable.h"
 
 #include "TTree.h"
 #include "TH1F.h"
@@ -45,21 +47,28 @@
 #include <string>
 #include <map>
 
-class HGCalAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+class HGCalAnalysis : public  edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::SharedResources>  {
 public:
 //
 // constructors and destructor
 //
+  HGCalAnalysis();
   explicit HGCalAnalysis(const edm::ParameterSet&);
   ~HGCalAnalysis();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  virtual void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override; 
+  virtual void endRun(edm::Run const& iEvent, edm::EventSetup const&) override ;
 
 private:
   virtual void beginJob() override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endJob() override;
+  // ---------parameters ----------------------------
+  bool readOfficialReco;
+  bool readCaloParticles;
+  std::string                detector;
+  bool                       rawRecHits;
 
  // ----------member data ---------------------------
 
@@ -73,6 +82,9 @@ private:
   edm::EDGetTokenT<std::vector<reco::PFCluster> > _pfClusters;
   edm::EDGetTokenT<std::vector<CaloParticle> > _caloParticles;
   edm::EDGetTokenT<std::vector<reco::HGCalMultiCluster> > _multiClusters;
+  edm::EDGetTokenT<std::vector<SimTrack> > _simTracks;
+  edm::EDGetTokenT<std::vector<SimVertex> > _simVertices;
+  edm::EDGetTokenT<edm::HepMCProduct> _hev;
 
   TTree                     *tree;
   AEvent                    *event;
@@ -84,22 +96,27 @@ private:
   ASimClusterCollection     *ascc;
   APFClusterCollection      *apfcc;
   ACaloParticleCollection   *acpc;
-  std::string                detector;
   int                        algo;
   HGCalDepthPreClusterer     pre;
-  bool                       rawRecHits;
   hgcal::RecHitTools         recHitTools;
+
+  // -------convenient tool to deal with simulated tracks
+  FSimEvent * mySimEvent;
+  edm::ParameterSet particleFilter;
 };
 
-
+HGCalAnalysis::HGCalAnalysis() {;}
 
 HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
+  readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
+  readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
   detector(iConfig.getParameter<std::string >("detector")),
-  rawRecHits(iConfig.getParameter<bool>("rawRecHits"))
+  rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
+  particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter"))
 {
   //now do what ever initialization is needed
   usesResource("TFileService");
-
+  mySimEvent = new FSimEvent(particleFilter);
 
   if(detector=="all") {
     _recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
@@ -115,12 +132,23 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
     algo = 3;
   }
   _clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
-  _vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
-  _part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
-  _simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
+  if(!readOfficialReco) {
+    _vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
+    _part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
+    _simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
+    if (!readCaloParticles) {
+      _caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
+    } 
+  }
+  else {
+    _hev = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared") );
+    _simTracks = consumes<std::vector<SimTrack> >(edm::InputTag("g4SimHits"));
+    _simVertices = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));    
+  }
   _pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
-  _caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
   _multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
+
+
 
   edm::Service<TFileService> fs;
   fs->make<TH1F>("total", "total", 100, 0, 5.);
@@ -154,7 +182,6 @@ HGCalAnalysis::~HGCalAnalysis()
 
 }
 
-
 void
 HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
@@ -168,17 +195,17 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   apfcc->clear();
   acpc->clear();
 
-
+  ParticleTable::Sentry ptable(mySimEvent->theTable());
   recHitTools.getEventSetup(iSetup);
 
-  int npart = 0;
-  int nhit  = 0;
-  int nhit_raw = 0;
-  int nclus = 0;
-  int nmclus = 0;
-  int nsimclus = 0;
-  int npfclus = 0;
-  int ncalopart = 0;
+  unsigned int npart = 0;
+  unsigned int nhit  = 0;
+  unsigned int nhit_raw = 0;
+  unsigned int nclus = 0;
+  unsigned int nmclus = 0;
+  unsigned int nsimclus = 0;
+  unsigned int npfclus = 0;
+  unsigned int ncalopart = 0;
 
   Handle<HGCRecHitCollection> recHitHandleEE;
   Handle<HGCRecHitCollection> recHitHandleFH;
@@ -188,22 +215,49 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(_clusters,clusterHandle);
   Handle<std::vector<TrackingVertex> > vtxHandle;
   Handle<std::vector<TrackingParticle> > partHandle;
-  iEvent.getByToken(_vtx,vtxHandle);
-  iEvent.getByToken(_part,partHandle);
-  const std::vector<TrackingVertex>& vtxs = *vtxHandle;
-  const std::vector<TrackingParticle>& part = *partHandle;
+  const std::vector<TrackingVertex>* vtxs;
+  const std::vector<TrackingParticle> * part;
 
+  Handle<edm::HepMCProduct> hevH;
+  Handle<std::vector<SimTrack> >simTracksHandle;
+  Handle<std::vector<SimVertex> >simVerticesHandle;
+
+  if(!readOfficialReco) {
+    iEvent.getByToken(_vtx,vtxHandle);
+    iEvent.getByToken(_part,partHandle);
+    vtxs = &(*vtxHandle);
+    part = &(*partHandle);
+  } else  // use SimTracks and HepMCProduct 
+    { 
+      iEvent.getByToken(_hev,hevH);
+      iEvent.getByToken(_simTracks,simTracksHandle);
+      iEvent.getByToken(_simVertices,simVerticesHandle);
+      //      std::cout << " Filling FSimEvent " << simTracksHandle->size() << " " << simVerticesHandle->size() << std::endl;
+      //      for(unsigned i=0; i<simTracksHandle->size();++i)
+      //	std::cout << "i " << (*simTracksHandle)[i].type() << std::endl;
+      mySimEvent->fill(*simTracksHandle,*simVerticesHandle);
+      
+    }
+    
+  
   Handle<std::vector<SimCluster> > simClusterHandle;
   Handle<std::vector<reco::PFCluster> > pfClusterHandle;
   Handle<std::vector<CaloParticle> > caloParticleHandle;
 
-  iEvent.getByToken(_simClusters, simClusterHandle);
-  iEvent.getByToken(_pfClusters, pfClusterHandle);
-  iEvent.getByToken(_caloParticles, caloParticleHandle);
+  const std::vector<SimCluster> * simClusters = 0 ; 
+  if(!readOfficialReco) {
+    iEvent.getByToken(_simClusters, simClusterHandle);
+    simClusters = &(*simClusterHandle);
+  }    
 
-  const std::vector<SimCluster>& simClusters = *simClusterHandle;
+  iEvent.getByToken(_pfClusters, pfClusterHandle);
   const std::vector<reco::PFCluster>& pfClusters = *pfClusterHandle;
-  const std::vector<CaloParticle>& caloParticles = *caloParticleHandle;
+
+  const std::vector<CaloParticle>* caloParticles;
+  if(readCaloParticles) {
+    iEvent.getByToken(_caloParticles, caloParticleHandle);
+    caloParticles = &(*caloParticleHandle);
+  }
 
   Handle<std::vector<reco::HGCalMultiCluster> > multiClusterHandle;
   iEvent.getByToken(_multiClusters, multiClusterHandle);
@@ -212,26 +266,46 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   float vx = 0.;
   float vy = 0.;
   float vz = 0.;
-  if(vtxs.size()!=0){
-    vx = vtxs[0].position().x();
-    vy = vtxs[0].position().y();
-    vz = vtxs[0].position().z();
-  }
+  
+  if(!readOfficialReco && vtxs->size()!=0){
+    vx = (*vtxs)[0].position().x();
+    vy = (*vtxs)[0].position().y();
+    vz = (*vtxs)[0].position().z();
+  } else {
+    HepMC::GenVertex * primaryVertex = *(hevH)->GetEvent()->vertices_begin();
+    vx = primaryVertex->position().x()/10.; // to put in official units
+    vy = primaryVertex->position().y()/10.;
+    vz = primaryVertex->position().z()/10.;
+  } 
   // TODO: should fall back to beam spot if no vertex
-  npart = part.size();
-  for(unsigned int i=0;i<part.size();++i){
-    if(part[i].parentVertex()->nGenVertices()>0){
-      float dvx=0.;
-      float dvy=0.;
-      float dvz=0.;
-      if(part[i].decayVertices().size()==1){
-	 dvx=part[i].decayVertices()[0]->position().x();
-	 dvy=part[i].decayVertices()[0]->position().y();
-	 dvz=part[i].decayVertices()[0]->position().z();
+  // Comment from FB: in principe no need, the HepMCProduct should always contain the primary vertex and could be used in all cases
+  if( !readOfficialReco) {
+    npart = part->size();
+    for(unsigned int i=0;i<npart;++i){
+      if((*part)[i].parentVertex()->nGenVertices()>0){
+	float dvx=0.;
+	float dvy=0.;
+	float dvz=0.;
+	if((*part)[i].decayVertices().size()==1){
+	  dvx=(*part)[i].decayVertices()[0]->position().x();
+	  dvy=(*part)[i].decayVertices()[0]->position().y();
+	  dvz=(*part)[i].decayVertices()[0]->position().z();
+	}
+	agpc->push_back(AGenPart((*part)[i].eta(),(*part)[i].phi(),(*part)[i].pt(),(*part)[i].energy(),dvx,dvy,dvz,(*part)[i].pdgId()));
       }
-      agpc->push_back(AGenPart(part[i].eta(),part[i].phi(),part[i].pt(),part[i].energy(),dvx,dvy,dvz,part[i].pdgId()));
     }
-  }
+  } else
+    {
+      npart = mySimEvent->nTracks();
+      for (unsigned int i=0;i<npart ; ++i) {
+	FSimTrack &myTrack = mySimEvent->track(i);
+	math::XYZTLorentzVectorD vtx(0,0,0,0);
+	if(!myTrack.noEndVertex()) 
+	  vtx = myTrack.endVertex().position();
+	
+	agpc->push_back(AGenPart(myTrack.momentum().eta(),myTrack.momentum().phi(),myTrack.momentum().pt(),myTrack.momentum().energy(),vtx.x(),vtx.y(),vtx.z(),myTrack.type()));
+      }
+    }
   //make a map detid-rechit
   std::map<DetId,const HGCRecHit*> hitmap;
   switch(algo){
@@ -434,16 +508,17 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 				  cl2dSeed));
   }
 
-  // loop over simClusters
-  for (std::vector<SimCluster>::const_iterator it_simClus = simClusters.begin(); it_simClus != simClusters.end(); ++it_simClus) {
-    ++nsimclus;
-    const std::vector<std::pair<uint32_t,float> > hits_and_fractions = it_simClus->hits_and_fractions();
-    std::vector<uint32_t> hits;
-    std::vector<float> fractions;
-    std::vector<unsigned int> layers;
-    std::vector<unsigned int> wafers;
-    std::vector<unsigned int> cells;
-    for (std::vector<std::pair<uint32_t,float> >::const_iterator it_haf = hits_and_fractions.begin(); it_haf != hits_and_fractions.end(); ++it_haf) {
+  if (!readOfficialReco) {
+    // loop over simClusters
+    for (std::vector<SimCluster>::const_iterator it_simClus = simClusters->begin(); it_simClus != simClusters->end(); ++it_simClus) {
+      ++nsimclus;
+      const std::vector<std::pair<uint32_t,float> > hits_and_fractions = it_simClus->hits_and_fractions();
+      std::vector<uint32_t> hits;
+      std::vector<float> fractions;
+      std::vector<unsigned int> layers;
+      std::vector<unsigned int> wafers;
+      std::vector<unsigned int> cells;
+      for (std::vector<std::pair<uint32_t,float> >::const_iterator it_haf = hits_and_fractions.begin(); it_haf != hits_and_fractions.end(); ++it_haf) {
         hits.push_back(it_haf->first);
         fractions.push_back(it_haf->second);
         layers.push_back(recHitTools.getLayerWithOffset(it_haf->first));
@@ -454,20 +529,20 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	  wafers.push_back(std::numeric_limits<unsigned int>::max());
 	  cells.push_back(std::numeric_limits<unsigned int>::max());
 	}
-    }
-    ascc->push_back(ASimCluster(it_simClus->pt(),
+      }
+      ascc->push_back(ASimCluster(it_simClus->pt(),
 				  it_simClus->eta(),
 				  it_simClus->phi(),
 				  it_simClus->energy(),
 				  it_simClus->simEnergy(),
 				  hits,
 				  fractions,
-                  layers,
-                  wafers,
-                  cells));
-
-  } // end loop over simClusters
-
+				  layers,
+				  wafers,
+				  cells));      
+    } // end loop over simClusters
+  }
+  
   // loop over pfClusters
   for (std::vector<reco::PFCluster>::const_iterator it_pfClus = pfClusters.begin(); it_pfClus != pfClusters.end(); ++it_pfClus) {
     ++npfclus;
@@ -479,22 +554,23 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   } // end loop over pfClusters
 
   // loop over caloParticles
-  for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles.begin(); it_caloPart != caloParticles.end(); ++it_caloPart) {
-    ++ncalopart;
-    const SimClusterRefVector simClusterRefVector = it_caloPart->simClusters();
-    std::vector<uint32_t> simClusterIndex;
-    for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
+  if (readCaloParticles) {
+    for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles->begin(); it_caloPart != caloParticles->end(); ++it_caloPart) {
+      ++ncalopart;
+      const SimClusterRefVector simClusterRefVector = it_caloPart->simClusters();
+      std::vector<uint32_t> simClusterIndex;
+      for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
         simClusterIndex.push_back((*it_sc).key());
-    }
-    acpc->push_back(ACaloParticle(it_caloPart->pt(),
-				  it_caloPart->eta(),
-				  it_caloPart->phi(),
-				  it_caloPart->energy(),
-				  it_caloPart->simEnergy(),
-                  simClusterIndex));
-
-  } // end loop over caloParticles
-
+      }
+      acpc->push_back(ACaloParticle(it_caloPart->pt(),
+				    it_caloPart->eta(),
+				    it_caloPart->phi(),
+				    it_caloPart->energy(),
+				    it_caloPart->simEnergy(),
+				    simClusterIndex));
+      
+    } // end loop over caloParticles
+  }
 
   event->set(iEvent.run(),iEvent.id().event(),npart,nhit,nhit_raw,nclus,nmclus,
          nsimclus, npfclus, ncalopart,
@@ -502,9 +578,19 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   tree->Fill();
 }
 
+void HGCalAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
+    edm::ESHandle < HepPDT::ParticleDataTable > pdt;
+    es.getData(pdt);
+    mySimEvent->initializePdt(&(*pdt));
+    std::cout << " FSimEvent initialized " << &(*pdt) << std::endl;
+}
+
+void HGCalAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {;}
+
 void
 HGCalAnalysis::beginJob()
 {
+  ;
 }
 
 // ------------ method called once each job just after ending the event loop  ------------

--- a/HGCalAnalysis/test/singleEle15.py
+++ b/HGCalAnalysis/test/singleEle15.py
@@ -48,7 +48,12 @@ process.TFileService = cms.Service("TFileService",
                                    )
 #process.imagingClusterHGCal.ecut = cms.double(0.01)
 #process.imagingClusterHGCal.eventsToDisplay = cms.untracked.uint32(2)
+process.hgcalLayerClusters.minClusters = cms.uint32(0)
+process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
+process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)
+process.hgcalLayerClusters.dependSensor = cms.bool(True)
+process.hgcalLayerClusters.ecut = cms.double(3.)
+process.hgcalLayerClusters.kappa = cms.double(9.)
 
-# If one wants to re-reconstruct the clusters. The code is located in​RecoLocalCalo/​HGCalRecAlgos/​src/​HGCalImagingAlgo.cc
-#process.p = cms.Path(process.HGCalLocalRecoSequence+process.ana)
-process.p = cms.Path( process.ana)
+process.p = cms.Path(process.HGCalLocalRecoSequence+process.ana)
+#process.p = cms.Path( process.ana)

--- a/HGCalAnalysis/test/singleEle15.py
+++ b/HGCalAnalysis/test/singleEle15.py
@@ -9,6 +9,7 @@ process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('RecoLocalCalo.HGCalRecProducers.HGCalLocalRecoSequence_cff')
 
 from FastSimulation.Event.ParticleFilter_cfi import *
 #process.load("RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cfi")
@@ -48,5 +49,6 @@ process.TFileService = cms.Service("TFileService",
 #process.imagingClusterHGCal.ecut = cms.double(0.01)
 #process.imagingClusterHGCal.eventsToDisplay = cms.untracked.uint32(2)
 
-#process.p = cms.Path(process.hgcalLayerClusters+process.ana)
+# If one wants to re-reconstruct the clusters. The code is located in​RecoLocalCalo/​HGCalRecAlgos/​src/​HGCalImagingAlgo.cc
+#process.p = cms.Path(process.HGCalLocalRecoSequence+process.ana)
 process.p = cms.Path( process.ana)

--- a/HGCalAnalysis/test/singleEle15.py
+++ b/HGCalAnalysis/test/singleEle15.py
@@ -14,19 +14,15 @@ from FastSimulation.Event.ParticleFilter_cfi import *
 #process.load("RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cfi")
 
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/0E600BFE-A3E2-E611-8D74-0\
-CC47A4C8E14.root',
-        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/20D4831D-A4E2-E611-8E46-0\
-CC47A4C8F30.root',
-        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/5E8E5EFB-A2E2-E611-9508-0\
-CC47A4D76AC.root',
-        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/68478B06-A3E2-E611-8626-0\
-025905A48EC.root'
+        'root://xrootd-cms.infn.it//store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/0E600BFE-A3E2-E611-8D74-0CC47A4C8E14.root',
+        'root://xrootd-cms.infn.it//store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/20D4831D-A4E2-E611-8E46-0CC47A4C8F30.root',
+        'root://xrootd-cms.infn.it//store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/5E8E5EFB-A2E2-E611-9508-0CC47A4D76AC.root',
+        'root://xrootd-cms.infn.it//store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/68478B06-A3E2-E611-8626-0025905A48EC.root'
     ),
 )
 
@@ -37,6 +33,7 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              rawRecHits = cms.bool(True),
                              readOfficialReco = cms.bool(True),
                              readCaloParticles = cms.bool(False),
+                             layerClusterPtThreshold = cms.double(0.01),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
                              )
 
@@ -45,7 +42,7 @@ process.ana.TestParticleFilter.protonEMin = cms.double(100000)
 process.ana.TestParticleFilter.etaMax = cms.double(3.1)
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("singleElePt15.root")
+                                   fileName = cms.string("singleElePt15-v3.root")
 
                                    )
 #process.imagingClusterHGCal.ecut = cms.double(0.01)

--- a/HGCalAnalysis/test/singleEle15.py
+++ b/HGCalAnalysis/test/singleEle15.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process("Demo")
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from FastSimulation.Event.ParticleFilter_cfi import *
+#process.load("RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cfi")
+
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root' with the source file you want to use
+    fileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/0E600BFE-A3E2-E611-8D74-0\
+CC47A4C8E14.root',
+        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/20D4831D-A4E2-E611-8E46-0\
+CC47A4C8F30.root',
+        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/5E8E5EFB-A2E2-E611-9508-0\
+CC47A4D76AC.root',
+        '/store/relval/CMSSW_8_2_0_patch1/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4-v1/10000/68478B06-A3E2-E611-8626-0\
+025905A48EC.root'
+    ),
+)
+
+
+
+process.ana = cms.EDAnalyzer('HGCalAnalysis',
+                             detector = cms.string("all"),
+                             rawRecHits = cms.bool(True),
+                             readOfficialReco = cms.bool(True),
+                             readCaloParticles = cms.bool(False),
+                             TestParticleFilter = ParticleFilterBlock.ParticleFilter
+                             )
+
+#Quite important
+process.ana.TestParticleFilter.protonEMin = cms.double(100000)
+process.ana.TestParticleFilter.etaMax = cms.double(3.1)
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("singleElePt15.root")
+
+                                   )
+#process.imagingClusterHGCal.ecut = cms.double(0.01)
+#process.imagingClusterHGCal.eventsToDisplay = cms.untracked.uint32(2)
+
+#process.p = cms.Path(process.hgcalLayerClusters+process.ana)
+process.p = cms.Path( process.ana)


### PR DESCRIPTION
When reading the Official Reco (controlled by a configurable), the extrapolation of all particles reaching the EE through the layers of EE are stored in the Gen collections. In that case, the FSimTracks are used instead of the tracking particles. The extrapolations are also stored for the generated particles from the GenEvent. The index of the Gen particle is also stored (-1 means that the particle results from an interaction in the tracker). 
Stores the 2D clusters that do not belong to a multicluster provided they pass a given pT threshold (configurable).

An additional example config file has been added. 