### PR TITLE
Tracking and propagation changes

### DIFF
--- a/HGCalAnalysis/interface/AObData.h
+++ b/HGCalAnalysis/interface/AObData.h
@@ -12,8 +12,8 @@ public:
   {
   }
   AGenPart(float i_eta, float i_phi, float i_pt, float i_energy,
-	   float i_dvx, float i_dvy,float i_dvz, int i_pid,int i_gen=-1,int i_reachedEE=-1) :
-  eta(i_eta),phi(i_phi),pt(i_pt),energy(i_energy),dvx(i_dvx),dvy(i_dvy),dvz(i_dvz),pid(i_pid),gen(i_gen),reachedEE(i_reachedEE)
+	   float i_dvx, float i_dvy,float i_dvz, int i_pid,int i_gen=-1,int i_reachedEE=-1, bool i_fromBeamPipe=true) :
+  eta(i_eta),phi(i_phi),pt(i_pt),energy(i_energy),dvx(i_dvx),dvy(i_dvy),dvz(i_dvz),pid(i_pid),gen(i_gen),reachedEE(i_reachedEE),fromBeamPipe(i_fromBeamPipe)
   {
   }
 
@@ -33,6 +33,7 @@ public:
   int pid;
   int gen;
   int reachedEE;
+  bool fromBeamPipe;
   std::vector<float> posx;
   std::vector<float> posy;
   std::vector<float> posz;
@@ -271,7 +272,17 @@ public:
 
   virtual ~ATrack() { }
 
+  inline void setExtrapolations(const std::vector<float>&x,const std::vector<float>& y,const std::vector<float>& z)
+  {
+    posx=x;
+    posy=y;
+    posz=z;
+  }
+
   float pt, eta, phi, energy;
+  std::vector<float> posx;
+  std::vector<float> posy;
+  std::vector<float> posz;
 
   ClassDef(ATrack,1)
 };

--- a/HGCalAnalysis/plugins/BuildFile.xml
+++ b/HGCalAnalysis/plugins/BuildFile.xml
@@ -4,11 +4,16 @@
 <use   name="DataFormats/CaloRecHit"/>
 <use   name="DataFormats/ParticleFlowReco"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/GeometrySurface"/>
 <use   name="RecoNtuples/HGCalAnalysis"/>
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/CaloAnalysis"/>
+<use   name="SimDataFormats/TrackingAnalysis"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="FastSimulation/Event"/>
+<use   name="TrackPropagation/RungeKutta"/>
+<use   name="MagneticField/Engine"/>
+<use   name="TrackingTools/Records"/>
 <use   name="hepmc"/>
 <use   name="heppdt"/>
 <library   file="*.cc" name="RecoNtuplesHGCalAnalysisPlugins">

--- a/HGCalAnalysis/test/twogamma_pt5_eta2_nosmear_calib.py
+++ b/HGCalAnalysis/test/twogamma_pt5_eta2_nosmear_calib.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("Demo")
-process.load('Configuration.Geometry.GeometryExtended2023D3Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load('RecoLocalCalo.HGCalRecHitDump.imagingClusterHGCal_cfi')
+#process.load('RecoLocalCalo.HGCalRecHitDump.imagingClusterHGCal_cfi')
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(5) )
 


### PR DESCRIPTION
- use of rechittools to get layer positions

- extend to BH the propagation

- add reco::Tracks propagation to all layers using RK propagator (with BField)

- change AGenPart format to save status of tracks (start and end positions)

- update accessors to TrackingParticle to select on hard scattering, PU BX=0, PU OOT

- other bug fixes and improvements