### PR TITLE
A few fixes and multicluster observables

### DIFF
--- a/HGCalAnalysis/plugins/BuildFile.xml
+++ b/HGCalAnalysis/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="SimDataFormats/TrackingAnalysis"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="FastSimulation/Event"/>
+<use   name="FastSimulation/CaloGeometryTools"/>
 <use   name="TrackPropagation/RungeKutta"/>
 <use   name="MagneticField/Engine"/>
 <use   name="TrackingTools/Records"/>

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -299,205 +299,205 @@ HGCalAnalysis::HGCalAnalysis() {
 }
 
 HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
-	readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
-	readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
-	layerClusterPtThreshold(iConfig.getParameter<double>("layerClusterPtThreshold")),
-	propagationPtThreshold(iConfig.getUntrackedParameter<double>("propagationPtThreshold",3.0)),
-	detector(iConfig.getParameter<std::string >("detector")),
-	rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
-	particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
+        readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
+        readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
+        layerClusterPtThreshold(iConfig.getParameter<double>("layerClusterPtThreshold")),
+        propagationPtThreshold(iConfig.getUntrackedParameter<double>("propagationPtThreshold",3.0)),
+        detector(iConfig.getParameter<std::string >("detector")),
+        rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
+        particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
         dEdXWeights(iConfig.getParameter<std::vector<double> >("dEdXWeights")),
-	invThicknessCorrection({1./1.132,1./1.092,1./1.084}),
-	pca_(new TPrincipal(3,"D"))
+        invThicknessCorrection({1./1.132,1./1.092,1./1.084}),
+        pca_(new TPrincipal(3,"D"))
 {
-	// now do what ever initialization is needed
-	mySimEvent = new FSimEvent(particleFilter);
+        // now do what ever initialization is needed
+        mySimEvent = new FSimEvent(particleFilter);
+  
+        if(detector=="all") {
+                _recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
+                _recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
+                _recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
+                algo = 1;
+        }else if(detector=="EM") {
+          _recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
+          algo = 2;
+        }else if(detector=="HAD") {
+          _recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
+          _recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
+          algo = 3;
+        }
+        _clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
+        _simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
+        _hev = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared") );
+        if(!readOfficialReco) {
+                _vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
+                _part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
+        }
+        else {
+                _simTracks = consumes<std::vector<SimTrack> >(edm::InputTag("g4SimHits"));
+                _simVertices = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));
+        }
+        if (readCaloParticles) {
+          _caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
+        }
+        _pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
+        _multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
+        _tracks = consumes<std::vector<reco::Track> >(edm::InputTag("generalTracks"));
+  
+  
+        usesResource(TFileService::kSharedResource);
+        edm::Service<TFileService> fs;
+        fs->make<TH1F>("total", "total", 100, 0, 5.);
+        
+        t = fs->make<TTree>("hgc","hgc");
+  
+        // event info
+        t->Branch("event", &ev_event);
+        t->Branch("lumi", &ev_lumi);
+        t->Branch("run", &ev_run);
+        t->Branch("vtx_x", &vtx_x);
+        t->Branch("vtx_y", &vtx_y);
+        t->Branch("vtx_z", &vtx_z);
+        
+        t->Branch("genpart_eta", &genpart_eta);
+        t->Branch("genpart_phi", &genpart_phi);
+        t->Branch("genpart_pt", &genpart_pt);
+        t->Branch("genpart_energy", &genpart_energy);
+        t->Branch("genpart_dvx", &genpart_dvx);
+        t->Branch("genpart_dvy", &genpart_dvy);
+        t->Branch("genpart_dvz", &genpart_dvz);
+        t->Branch("genpart_fbrem", &genpart_fbrem);
+        t->Branch("genpart_pid", &genpart_pid);
+        t->Branch("genpart_gen", &genpart_gen);
+        t->Branch("genpart_reachedEE", &genpart_reachedEE);
+        t->Branch("genpart_fromBeamPipe", &genpart_fromBeamPipe);
+        t->Branch("genpart_posx", &genpart_posx);
+        t->Branch("genpart_posy", &genpart_posy);
+        t->Branch("genpart_posz", &genpart_posz);
+        
+        ////////////////////
+        // RecHits
+        // associated to layer clusters
+        t->Branch("rechit_eta", &rechit_eta);
+        t->Branch("rechit_phi", &rechit_phi);
+        t->Branch("rechit_pt", &rechit_pt);
+        t->Branch("rechit_energy", &rechit_energy);
+        t->Branch("rechit_x", &rechit_x);
+        t->Branch("rechit_y", &rechit_y);
+        t->Branch("rechit_z", &rechit_z);
+        t->Branch("rechit_time", &rechit_time);
+        t->Branch("rechit_thickness", &rechit_thickness);
+        t->Branch("rechit_layer", &rechit_layer);
+        t->Branch("rechit_wafer", &rechit_wafer);
+        t->Branch("rechit_cell", &rechit_cell);
+        t->Branch("rechit_detid", &rechit_detid);
+        t->Branch("rechit_isHalf", &rechit_isHalf);
+        t->Branch("rechit_flags", &rechit_flags);
+        t->Branch("rechit_cluster2d", &rechit_cluster2d);
+  
+        ////////////////////
+        // layer clusters
+        //
+        t->Branch("cluster2d_eta", &cluster2d_eta);
+        t->Branch("cluster2d_phi", &cluster2d_phi);
+        t->Branch("cluster2d_pt", &cluster2d_pt);
+        t->Branch("cluster2d_energy", &cluster2d_energy);
+        t->Branch("cluster2d_x", &cluster2d_x);
+        t->Branch("cluster2d_y", &cluster2d_y);
+        t->Branch("cluster2d_z", &cluster2d_z);
+        t->Branch("cluster2d_layer", &cluster2d_layer);
+        t->Branch("cluster2d_nhitCore", &cluster2d_nhitCore);
+        t->Branch("cluster2d_nhitAll", &cluster2d_nhitAll);
+        t->Branch("cluster2d_multicluster", &cluster2d_multicluster);
+        t->Branch("cluster2d_rechits", &cluster2d_rechits);
+        t->Branch("cluster2d_rechitSeed", &cluster2d_rechitSeed);
+  
+        ////////////////////
+        // multi clusters
+        //
+        t->Branch("multiclus_eta", &multiclus_eta);
+        t->Branch("multiclus_phi", &multiclus_phi);
+        t->Branch("multiclus_pt", &multiclus_pt);
+        t->Branch("multiclus_energy", &multiclus_energy);
+        t->Branch("multiclus_z", &multiclus_z);
+        t->Branch("multiclus_slopeX", &multiclus_slopeX);
+        t->Branch("multiclus_slopeY", &multiclus_slopeY);
+        t->Branch("multiclus_cluster2d", &multiclus_cluster2d);
+        t->Branch("multiclus_cl2dSeed", &multiclus_cl2dSeed);
+        t->Branch("multiclus_pcaAxisX", &multiclus_pcaAxisX); 
+        t->Branch("multiclus_pcaAxisY", &multiclus_pcaAxisY); 
+        t->Branch("multiclus_pcaAxisZ", &multiclus_pcaAxisZ);
+        t->Branch("multiclus_pcaPosX", &multiclus_pcaPosX);  
+        t->Branch("multiclus_pcaPosY", &multiclus_pcaPosY);  
+        t->Branch("multiclus_pcaPosZ", &multiclus_pcaPosZ);  
+        t->Branch("multiclus_eigenVal1", &multiclus_eigenVal1);
+        t->Branch("multiclus_eigenVal2", &multiclus_eigenVal2);
+        t->Branch("multiclus_eigenVal3", &multiclus_eigenVal3);
+        t->Branch("multiclus_eigenSig1", &multiclus_eigenSig1);
+        t->Branch("multiclus_eigenSig2", &multiclus_eigenSig2);
+        t->Branch("multiclus_eigenSig3", &multiclus_eigenSig3);
+        t->Branch("multiclus_siguu", &multiclus_siguu);
+        t->Branch("multiclus_sigvv", &multiclus_sigvv);
+        t->Branch("multiclus_sigrad", &multiclus_sigrad);
+        t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
+        t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
+        t->Branch("multiclus_firstLay",&multiclus_firstLay);
+        t->Branch("multiclus_lastLay",&multiclus_lastLay);
+        t->Branch("multiclus_NLay",&multiclus_NLay);
+        
+        
+        ////////////////////
+        // sim clusters
+        //
+        t->Branch("simcluster_eta", &simcluster_eta);
+        t->Branch("simcluster_phi", &simcluster_phi);
+        t->Branch("simcluster_pt", &simcluster_pt);
+        t->Branch("simcluster_energy", &simcluster_energy);
+        t->Branch("simcluster_simEnergy", &simcluster_simEnergy);
+        t->Branch("simcluster_hits", &simcluster_hits);
+        t->Branch("simcluster_fractions", &simcluster_fractions);
+        t->Branch("simcluster_layers", &simcluster_layers);
+        t->Branch("simcluster_wafers", &simcluster_wafers);
+        t->Branch("simcluster_cells", &simcluster_cells);
+        
+        
+        ////////////////////
+        // PF clusters
+        //
+        t->Branch("pfcluster_eta", &pfcluster_eta);
+        t->Branch("pfcluster_phi", &pfcluster_phi);
+        t->Branch("pfcluster_pt", &pfcluster_pt);
+        t->Branch("pfcluster_energy", &pfcluster_energy);
+        
+        
+        ////////////////////
+        // calo particles
+        //
+        t->Branch("calopart_eta", &calopart_eta);
+        t->Branch("calopart_phi", &calopart_phi);
+        t->Branch("calopart_pt", &calopart_pt);
+        t->Branch("calopart_energy", &calopart_energy);
+        t->Branch("calopart_simEnergy", &calopart_simEnergy);
+        t->Branch("calopart_simClusterIndex", &calopart_simClusterIndex);
+  
 
-	if(detector=="all") {
-		_recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
-		_recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-		_recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
-		algo = 1;
-	}else if(detector=="EM") {
-		_recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
-		algo = 2;
-	}else if(detector=="HAD") {
-		_recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-		_recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
-		algo = 3;
-	}
-	_clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
-	_simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
-	_hev = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared") );
-	if(!readOfficialReco) {
-		_vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
-		_part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
-	}
-	else {
-		_simTracks = consumes<std::vector<SimTrack> >(edm::InputTag("g4SimHits"));
-		_simVertices = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));
-	}
-	if (readCaloParticles) {
-		_caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
-	}
-	_pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
-	_multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
-	_tracks = consumes<std::vector<reco::Track> >(edm::InputTag("generalTracks"));
-
-
-	usesResource(TFileService::kSharedResource);
-	edm::Service<TFileService> fs;
-	fs->make<TH1F>("total", "total", 100, 0, 5.);
-
-	t = fs->make<TTree>("hgc","hgc");
-
-	// event info
-	t->Branch("event", &ev_event);
-	t->Branch("lumi", &ev_lumi);
-	t->Branch("run", &ev_run);
-	t->Branch("vtx_x", &vtx_x);
-	t->Branch("vtx_y", &vtx_y);
-	t->Branch("vtx_z", &vtx_z);
-
-	t->Branch("genpart_eta", &genpart_eta);
-	t->Branch("genpart_phi", &genpart_phi);
-	t->Branch("genpart_pt", &genpart_pt);
-	t->Branch("genpart_energy", &genpart_energy);
-	t->Branch("genpart_dvx", &genpart_dvx);
-	t->Branch("genpart_dvy", &genpart_dvy);
-	t->Branch("genpart_dvz", &genpart_dvz);
-	t->Branch("genpart_fbrem", &genpart_fbrem);
-	t->Branch("genpart_pid", &genpart_pid);
-	t->Branch("genpart_gen", &genpart_gen);
-	t->Branch("genpart_reachedEE", &genpart_reachedEE);
-	t->Branch("genpart_fromBeamPipe", &genpart_fromBeamPipe);
-	t->Branch("genpart_posx", &genpart_posx);
-	t->Branch("genpart_posy", &genpart_posy);
-	t->Branch("genpart_posz", &genpart_posz);
-
-	////////////////////
-	// RecHits
-	// associated to layer clusters
-	t->Branch("rechit_eta", &rechit_eta);
-	t->Branch("rechit_phi", &rechit_phi);
-	t->Branch("rechit_pt", &rechit_pt);
-	t->Branch("rechit_energy", &rechit_energy);
-	t->Branch("rechit_x", &rechit_x);
-	t->Branch("rechit_y", &rechit_y);
-	t->Branch("rechit_z", &rechit_z);
-	t->Branch("rechit_time", &rechit_time);
-	t->Branch("rechit_thickness", &rechit_thickness);
-	t->Branch("rechit_layer", &rechit_layer);
-	t->Branch("rechit_wafer", &rechit_wafer);
-	t->Branch("rechit_cell", &rechit_cell);
-	t->Branch("rechit_detid", &rechit_detid);
-	t->Branch("rechit_isHalf", &rechit_isHalf);
-	t->Branch("rechit_flags", &rechit_flags);
-	t->Branch("rechit_cluster2d", &rechit_cluster2d);
-
-	////////////////////
-	// layer clusters
-	//
-	t->Branch("cluster2d_eta", &cluster2d_eta);
-	t->Branch("cluster2d_phi", &cluster2d_phi);
-	t->Branch("cluster2d_pt", &cluster2d_pt);
-	t->Branch("cluster2d_energy", &cluster2d_energy);
-	t->Branch("cluster2d_x", &cluster2d_x);
-	t->Branch("cluster2d_y", &cluster2d_y);
-	t->Branch("cluster2d_z", &cluster2d_z);
-	t->Branch("cluster2d_layer", &cluster2d_layer);
-	t->Branch("cluster2d_nhitCore", &cluster2d_nhitCore);
-	t->Branch("cluster2d_nhitAll", &cluster2d_nhitAll);
-	t->Branch("cluster2d_multicluster", &cluster2d_multicluster);
-	t->Branch("cluster2d_rechits", &cluster2d_rechits);
-	t->Branch("cluster2d_rechitSeed", &cluster2d_rechitSeed);
-
-	////////////////////
-	// multi clusters
-	//
-	t->Branch("multiclus_eta", &multiclus_eta);
-	t->Branch("multiclus_phi", &multiclus_phi);
-	t->Branch("multiclus_pt", &multiclus_pt);
-	t->Branch("multiclus_energy", &multiclus_energy);
-	t->Branch("multiclus_z", &multiclus_z);
-	t->Branch("multiclus_slopeX", &multiclus_slopeX);
-	t->Branch("multiclus_slopeY", &multiclus_slopeY);
-	t->Branch("multiclus_cluster2d", &multiclus_cluster2d);
-	t->Branch("multiclus_cl2dSeed", &multiclus_cl2dSeed);
-	t->Branch("multiclus_pcaAxisX", &multiclus_pcaAxisX); 
-	t->Branch("multiclus_pcaAxisY", &multiclus_pcaAxisY); 
-	t->Branch("multiclus_pcaAxisZ", &multiclus_pcaAxisZ);
-	t->Branch("multiclus_pcaPosX", &multiclus_pcaPosX);  
-	t->Branch("multiclus_pcaPosY", &multiclus_pcaPosY);  
-	t->Branch("multiclus_pcaPosZ", &multiclus_pcaPosZ);  
-	t->Branch("multiclus_eigenVal1", &multiclus_eigenVal1);
-	t->Branch("multiclus_eigenVal2", &multiclus_eigenVal2);
-	t->Branch("multiclus_eigenVal3", &multiclus_eigenVal3);
-	t->Branch("multiclus_eigenSig1", &multiclus_eigenSig1);
-	t->Branch("multiclus_eigenSig2", &multiclus_eigenSig2);
-	t->Branch("multiclus_eigenSig3", &multiclus_eigenSig3);
-	t->Branch("multiclus_siguu", &multiclus_siguu);
-	t->Branch("multiclus_sigvv", &multiclus_sigvv);
-	t->Branch("multiclus_sigrad", &multiclus_sigrad);
-	t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
-	t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
-	t->Branch("multiclus_firstLay",&multiclus_firstLay);
-	t->Branch("multiclus_lastLay",&multiclus_lastLay);
-	t->Branch("multiclus_NLay",&multiclus_NLay);
-
-
-	////////////////////
-	// sim clusters
-	//
-	t->Branch("simcluster_eta", &simcluster_eta);
-	t->Branch("simcluster_phi", &simcluster_phi);
-	t->Branch("simcluster_pt", &simcluster_pt);
-	t->Branch("simcluster_energy", &simcluster_energy);
-	t->Branch("simcluster_simEnergy", &simcluster_simEnergy);
-	t->Branch("simcluster_hits", &simcluster_hits);
-	t->Branch("simcluster_fractions", &simcluster_fractions);
-	t->Branch("simcluster_layers", &simcluster_layers);
-	t->Branch("simcluster_wafers", &simcluster_wafers);
-	t->Branch("simcluster_cells", &simcluster_cells);
-
-
-	////////////////////
-	// PF clusters
-	//
-	t->Branch("pfcluster_eta", &pfcluster_eta);
-	t->Branch("pfcluster_phi", &pfcluster_phi);
-	t->Branch("pfcluster_pt", &pfcluster_pt);
-	t->Branch("pfcluster_energy", &pfcluster_energy);
-
-
-	////////////////////
-	// calo particles
-	//
-	t->Branch("calopart_eta", &calopart_eta);
-	t->Branch("calopart_phi", &calopart_phi);
-	t->Branch("calopart_pt", &calopart_pt);
-	t->Branch("calopart_energy", &calopart_energy);
-	t->Branch("calopart_simEnergy", &calopart_simEnergy);
-	t->Branch("calopart_simClusterIndex", &calopart_simClusterIndex);
-
-
-	////////////////////
-	// high purity tracks
-	//
-	t->Branch("track_eta", &track_eta);
-	t->Branch("track_phi", &track_phi);
-	t->Branch("track_pt", &track_pt);
-	t->Branch("track_energy", &track_energy);
-	t->Branch("track_charge", &track_charge);
-	t->Branch("track_posx", &track_posx);
-	t->Branch("track_posy", &track_posy);
-	t->Branch("track_posz", &track_posz);
-
+        ////////////////////
+        // high purity trackstatep
+        //
+        t->Branch("track_eta", &track_eta);
+        t->Branch("track_phi", &track_phi);
+        t->Branch("track_pt", &track_pt);
+        t->Branch("track_energy", &track_energy);
+        t->Branch("track_charge", &track_charge);
+        t->Branch("track_posx", &track_posx);
+        t->Branch("track_posy", &track_posy);
+        t->Branch("track_posz", &track_posz);
+        
 }
 HGCalAnalysis::~HGCalAnalysis()
 {
-
-	// do anything here that needs to be done at desctruction time
+  
+        // do anything here that needs to be done at desctruction time
 	// (e.g. close files, deallocate resources etc.)
 
 }
@@ -507,7 +507,7 @@ HGCalAnalysis::~HGCalAnalysis()
 //
 void HGCalAnalysis::clearVariables() {
 
-	ev_run = 0;
+        ev_run = 0;
 	ev_lumi = 0;
 	ev_event = 0;
 	vtx_x = 0;
@@ -961,15 +961,17 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		std::vector<float> radsigvv;
 		std::vector<float> sigrad;
 
-		for(float radius=1.;  radius<=10.; radius+=1.) {
-		  computeWidth(multiClusters[i],barycenter,axis,sigu,sigv,radius);
-		  sigrad.push_back(radius);
-		  radsiguu.push_back(sigu);
-		  radsigvv.push_back(sigv);
-		  if (radius>4.9 && radius < 5.1) {
-		    multiclus_siguu.push_back(sigu);
-		    multiclus_sigvv.push_back(sigv);
-		  }
+                //		for(float radius=1.;  radius<=10.; radius+=1.) {
+                float radius=5.;
+                
+                computeWidth(multiClusters[i],barycenter,axis,sigu,sigv,radius);
+                sigrad.push_back(radius);
+                radsiguu.push_back(sigu);
+                radsigvv.push_back(sigv);
+                if (radius>4.9 && radius < 5.1) {
+                  multiclus_siguu.push_back(sigu);
+                  multiclus_sigvv.push_back(sigv);
+                  //                }
 		}
 
 		multiclus_pcaAxisX.push_back(axis.x());
@@ -1080,398 +1082,398 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		simcluster_cells.push_back(cells);
 
 	} // end loop over simClusters
-
+	
 	// loop over pfClusters
 	for (std::vector<reco::PFCluster>::const_iterator it_pfClus = pfClusters.begin(); it_pfClus != pfClusters.end(); ++it_pfClus) {
-
-		pfcluster_eta.push_back(it_pfClus->eta());
-		pfcluster_phi.push_back(it_pfClus->phi());
-		pfcluster_pt.push_back(it_pfClus->pt());
-		pfcluster_energy.push_back(it_pfClus->energy());
-
+	  
+	  pfcluster_eta.push_back(it_pfClus->eta());
+	  pfcluster_phi.push_back(it_pfClus->phi());
+	  pfcluster_pt.push_back(it_pfClus->pt());
+	  pfcluster_energy.push_back(it_pfClus->energy());
+	  
 	} // end loop over pfClusters
-
+	
 	// loop over caloParticles
 	if (readCaloParticles) {
-		for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles->begin(); it_caloPart != caloParticles->end(); ++it_caloPart) {
-			const SimClusterRefVector simClusterRefVector = it_caloPart->simClusters();
-			std::vector<uint32_t> simClusterIndex;
-			for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
-				simClusterIndex.push_back((*it_sc).key());
-			}
-
-			calopart_eta.push_back(it_caloPart->eta());
-			calopart_phi.push_back(it_caloPart->phi());
-			calopart_pt.push_back(it_caloPart->pt());
-			calopart_energy.push_back(it_caloPart->energy());
-			calopart_simEnergy.push_back(it_caloPart->simEnergy());
-			calopart_simClusterIndex.push_back(simClusterIndex);
-
-		} // end loop over caloParticles
+	  for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles->begin(); it_caloPart != caloParticles->end(); ++it_caloPart) {
+	    const SimClusterRefVector simClusterRefVector = it_caloPart->simClusters();
+	    std::vector<uint32_t> simClusterIndex;
+	    for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
+	      simClusterIndex.push_back((*it_sc).key());
+	    }
+	    
+	    calopart_eta.push_back(it_caloPart->eta());
+	    calopart_phi.push_back(it_caloPart->phi());
+	    calopart_pt.push_back(it_caloPart->pt());
+	    calopart_energy.push_back(it_caloPart->energy());
+	    calopart_simEnergy.push_back(it_caloPart->simEnergy());
+	    calopart_simClusterIndex.push_back(simClusterIndex);
+	    
+	  } // end loop over caloParticles
 	}
-
+	
 	// loop over tracks
-
+	
 	//  random = new RandomEngineAndDistribution(iEvent.streamID());
-
+	
 	// prepare for RK propagation
 	defaultRKPropagator::Product prod( aField, alongMomentum, 5.e-5);
 	auto & RKProp = prod.propagator;
-
-
+	
+	
 	for (std::vector<reco::Track>::const_iterator it_track = tracks.begin(); it_track != tracks.end(); ++it_track) {
+	  
+	  if (!it_track->quality(reco::Track::highPurity)) continue;
+	  
+	  double energy = it_track->pt() * cosh(it_track->eta());
+	  
+	  //save info about reconstructed tracks propoagation to hgcal layers (ony for pt>propagationPtThreshold tracks)
+	  std::vector<float> xp,yp,zp;
+	  
+	  if (it_track->pt()>= propagationPtThreshold) {
+	    
+	    // Define error matrix
+	    ROOT::Math::SMatrixIdentity id;
+	    AlgebraicSymMatrix55 C(id);
+	    C *= 0.01;
+	    CurvilinearTrajectoryError err(C);
+	    typedef TrajectoryStateOnSurface TSOS;
+	    
+	    GlobalPoint startingPosition(it_track->vx(),it_track->vy(),it_track->vz());
+	    GlobalVector startingMomentum(it_track->px(),it_track->py(),it_track->pz());
+	    
+	    Plane::PlanePointer startingPlane = Plane::build( Plane::PositionType (it_track->vx(),it_track->vy(),it_track->vz()), Plane::RotationType () );
+	    
+	    TSOS startingStateP(GlobalTrajectoryParameters(startingPosition,startingMomentum, it_track->charge(), aField), err, *startingPlane);
+	    
+	    for(unsigned il=0; il<layerPositions.size(); ++il) {
+	      float xp_curr=0;
+	      float yp_curr=0;
+	      float zp_curr=0;
+	      
+	      for (int zside = -1; zside <=1; zside+=2)
+		{
+		  // clearly try both sides
+		  Plane::PlanePointer endPlane = Plane::build( Plane::PositionType (0,0,zside*layerPositions[il]), Plane::RotationType());
+		  try{
+		    /*
+		      std::cout << "Trying from " <<
+		      " layer " << il <<
+		      " starting point " << startingStateP.globalPosition() <<
+		      std::endl;
+		    */
+		    TSOS trackStateP = RKProp.propagate( startingStateP, *endPlane);
+		    if (trackStateP.isValid()) {
+		      xp_curr=trackStateP.globalPosition().x();
+		      yp_curr=trackStateP.globalPosition().y();
+		      zp_curr=trackStateP.globalPosition().z();
+		      
+		      // std::cout << "Succesfully finished Positive track propagation  -------------- with RK: " << trackStateP.globalPosition() << std::endl;
+		    }
+		  }
+		  catch (...) {
+		    std::cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << std::endl;
+		  }
+		}
+	      xp.push_back(xp_curr);
+	      yp.push_back(yp_curr);
+	      zp.push_back(zp_curr);
+	    } // closes loop on layers
+	  } // closes conditions pt>3
+	  
+	  // save info in tree
+	  track_pt.push_back(it_track->pt());
+	  track_pt.push_back(it_track->eta());
+	  track_pt.push_back(it_track->phi());
+	  track_pt.push_back(energy);
+	  track_pt.push_back(it_track->charge());
+	  track_posx.push_back(xp);
+	  track_posy.push_back(yp);
+	  track_posz.push_back(zp);
+	  
+	} // end loop over tracks
+	
+	ev_event = iEvent.id().event();
+	ev_lumi = iEvent.id().luminosityBlock();
+	ev_run = iEvent.id().run();
+	
+	vtx_x = vx;
+	vtx_y = vy;
+	vtx_z = vz;
+	
+	t->Fill();
+}
 
-		if (!it_track->quality(reco::Track::highPurity)) continue;
+void HGCalAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
+  
+            edm::ESHandle < HepPDT::ParticleDataTable > pdt;
+            es.getData(pdt);
+            mySimEvent->initializePdt(&(*pdt));
+  
+            retrieveLayerPositions(es,52);
+  
+            edm::ESHandle<MagneticField> magfield;
+            es.get<IdealMagneticFieldRecord>().get(magfield);
+  
+            aField=&(*magfield);
+  
+}
 
-		double energy = it_track->pt() * cosh(it_track->eta());
+void HGCalAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {
+}
 
-		 //save info about reconstructed tracks propoagation to hgcal layers (ony for pt>propagationPtThreshold tracks)
-		 std::vector<float> xp,yp,zp;
-
-		 if (it_track->pt()>= propagationPtThreshold) {
-
-			 // Define error matrix
-			 ROOT::Math::SMatrixIdentity id;
-			 AlgebraicSymMatrix55 C(id);
-			 C *= 0.01;
-			 CurvilinearTrajectoryError err(C);
-			 typedef TrajectoryStateOnSurface TSOS;
-
-			 GlobalPoint startingPosition(it_track->vx(),it_track->vy(),it_track->vz());
-			 GlobalVector startingMomentum(it_track->px(),it_track->py(),it_track->pz());
-
-			 Plane::PlanePointer startingPlane = Plane::build( Plane::PositionType (it_track->vx(),it_track->vy(),it_track->vz()), Plane::RotationType () );
-
-			 TSOS startingStateP(GlobalTrajectoryParameters(startingPosition,startingMomentum, it_track->charge(), aField), err, *startingPlane);
-
-			 for(unsigned il=0; il<layerPositions.size(); ++il) {
-				 float xp_curr=0;
-				 float yp_curr=0;
-				 float zp_curr=0;
-
-				 for (int zside = -1; zside <=1; zside+=2)
-				 {
-					 // clearly try both sides
-					 Plane::PlanePointer endPlane = Plane::build( Plane::PositionType (0,0,zside*layerPositions[il]), Plane::RotationType());
-					 try{
-						 /*
-						    std::cout << "Trying from " <<
-						    " layer " << il <<
-						    " starting point " << startingStateP.globalPosition() <<
-						    std::endl;
-						  */
-						 TSOS trackStateP = RKProp.propagate( startingStateP, *endPlane);
-						 if (trackStateP.isValid()) {
-							 xp_curr=trackStateP.globalPosition().x();
-							 yp_curr=trackStateP.globalPosition().y();
-							 zp_curr=trackStateP.globalPosition().z();
-
-							 // std::cout << "Succesfully finished Positive track propagation  -------------- with RK: " << trackStateP.globalPosition() << std::endl;
-						 }
-					 }
-					 catch (...) {
-						 std::cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << std::endl;
-					 }
-				 }
-				 xp.push_back(xp_curr);
-				 yp.push_back(yp_curr);
-				 zp.push_back(zp_curr);
-			 } // closes loop on layers
-		 } // closes conditions pt>3
-
-		 // save info in tree
-		 track_pt.push_back(it_track->pt());
-		 track_pt.push_back(it_track->eta());
-		 track_pt.push_back(it_track->phi());
-		 track_pt.push_back(energy);
-		 track_pt.push_back(it_track->charge());
-		 track_posx.push_back(xp);
-		 track_posy.push_back(yp);
-		 track_posz.push_back(zp);
-
-	 } // end loop over tracks
-
-	 ev_event = iEvent.id().event();
-	 ev_lumi = iEvent.id().luminosityBlock();
-	 ev_run = iEvent.id().run();
-
-	 vtx_x = vx;
-	 vtx_y = vy;
-	 vtx_z = vz;
-
-	 t->Fill();
- }
-
- void HGCalAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
-
-	 edm::ESHandle < HepPDT::ParticleDataTable > pdt;
-	 es.getData(pdt);
-	 mySimEvent->initializePdt(&(*pdt));
-
-	 retrieveLayerPositions(es,52);
-
-	 edm::ESHandle<MagneticField> magfield;
-	 es.get<IdealMagneticFieldRecord>().get(magfield);
-
-	 aField=&(*magfield);
-
- }
-
- void HGCalAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {
- }
-
- void
- HGCalAnalysis::beginJob()
- {
-	 ;
- }
+void
+HGCalAnalysis::beginJob()
+{
+            ;
+}
 
  // ------------ method called once each job just after ending the event loop  ------------
- void
- HGCalAnalysis::endJob()
- {
- }
+void
+HGCalAnalysis::endJob()
+{
+}
 
  // ------------ method to be called once --------------------------------------------------
 
 
- void HGCalAnalysis::retrieveLayerPositions(const edm::EventSetup& es, unsigned layers)
- {
-	 recHitTools.getEventSetup(es);
-
-	 DetId id;
-	 for(unsigned ilayer=1; ilayer<=layers; ++ilayer) {
-		 if (ilayer<=28) id=HGCalDetId(ForwardSubdetector::HGCEE,1,ilayer,1,50,1);
-		 if (ilayer>28 && ilayer<=40) id=HGCalDetId(ForwardSubdetector::HGCHEF,1,ilayer-28,1,50,1);
-		 if (ilayer>40) id=HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, ilayer-40);
-		 const GlobalPoint pos = recHitTools.getPosition(id);
-//		 std::cout << "GEOM " ;
-//		 std::cout << " layer " << ilayer << " " << pos.z() << std::endl;
-		 
-		 layerPositions.push_back(pos.z());
-	}
+void HGCalAnalysis::retrieveLayerPositions(const edm::EventSetup& es, unsigned layers)
+{
+  recHitTools.getEventSetup(es);
+  
+  DetId id;
+  for(unsigned ilayer=1; ilayer<=layers; ++ilayer) {
+    if (ilayer<=28) id=HGCalDetId(ForwardSubdetector::HGCEE,1,ilayer,1,50,1);
+    if (ilayer>28 && ilayer<=40) id=HGCalDetId(ForwardSubdetector::HGCHEF,1,ilayer-28,1,50,1);
+    if (ilayer>40) id=HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, ilayer-40);
+    const GlobalPoint pos = recHitTools.getPosition(id);
+    //		 std::cout << "GEOM " ;
+    //		 std::cout << " layer " << ilayer << " " << pos.z() << std::endl;
+    
+    layerPositions.push_back(pos.z());
+  }
 }
 
 
 int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerCluster, const bool& fillRecHits, const int& multiClusterIndex) {
-
-	// std::cout << "in fillLayerCluster" << std::endl;
-	const std::vector< std::pair<DetId, float> > &hf = layerCluster->hitsAndFractions();
-	std::vector<unsigned int> rhIndices;
-	int ncoreHit = 0;
-	int layer = 0;
-	int rhSeed = 0;
-	if (!fillRecHits) {
-		rhSeed = -1;
-	}
-	float maxEnergy = -1.;
-	Double_t pcavars[3];
-	unsigned hfsize=hf.size();
-
-	for(unsigned int j = 0; j < hfsize; j++) {
-		//here we loop over detid/fraction pairs
-		float fraction = hf[j].second;
-		const DetId rh_detid = hf[j].first;
-		layer = recHitTools.getLayerWithOffset(rh_detid);
-		const HGCRecHit *hit = hitmap[rh_detid];
-		ncoreHit += int(fraction);
-		
-		double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
-		double mip=dEdXWeights[layer]*0.001; // convert in GeV
-		if (thickness > 99. && thickness < 101) 
-		  mip *= invThicknessCorrection[0];
-		else if (thickness > 199 && thickness <201)
-		  mip *= invThicknessCorrection[1];
-		else if (thickness > 299 && thickness <301)
-		  mip *= invThicknessCorrection[2];
-		//		std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;
-
-		if(multiClusterIndex>=0 and fraction>0 && mip > 0) {
-		  pcavars[0] = recHitTools.getPosition(rh_detid).x();
-		  pcavars[1] = recHitTools.getPosition(rh_detid).y();
-		  pcavars[2] = recHitTools.getPosition(rh_detid).z();
-		  //		  std::cout << pcavars[0] << " " << pcavars[1] << " " << pcavars[2] << std::endl;
-		  //		  std::cout << " Multiplicity " << int(hit->energy()/mip) <<std::endl;
-		  if(pcavars[2]!=0)
-		    for (int i=0; i<int(hit->energy()/mip); ++i)
-		      pca_->AddRow(pcavars);
-		}
-
-
-		if (fillRecHits) {
-			if(storedRecHits.find(rh_detid)==storedRecHits.end() ) {
-				// std::cout << "in fillLayerCluster: RecHit not yet filled" << std::endl;
-				// std::cout << "in fillLayerCluster: hit energy: " << hit->energy() << std::endl;
-				// std::cout << "in fillLayerCluster: first hit energy: " << maxEnergy << std::endl;
-				if(hit->energy() > maxEnergy) {
-					rhSeed = rechit_index;
-					maxEnergy = hit->energy();
-				}
-				rhIndices.push_back(rechit_index);
-				fillRecHit(rh_detid, fraction, layer, cluster_index);
-			}
-			else {
-				// need to see what to do about existing rechits in case of sharing
-				std::cout << "RecHit already filled for different layer cluster: " << int(rh_detid) << std::endl;
-			}
-		}
-	}
-
-	double pt = layerCluster->energy() / cosh(layerCluster->eta());
-
-	cluster2d_eta.push_back(layerCluster->eta());
-	cluster2d_phi.push_back(layerCluster->phi());
-	cluster2d_pt.push_back(pt);
-	cluster2d_energy.push_back(layerCluster->energy());
-	cluster2d_x.push_back(layerCluster->x());
-	cluster2d_y.push_back(layerCluster->y());
-	cluster2d_z.push_back(layerCluster->z());
-	cluster2d_layer.push_back(layer);
-	cluster2d_nhitCore.push_back(ncoreHit);
-	cluster2d_nhitAll.push_back(hf.size());
-	cluster2d_multicluster.push_back(multiClusterIndex);
-	cluster2d_rechitSeed.push_back(rhSeed);
-	cluster2d_rechits.push_back(rhIndices);
-
-	storedLayerClusters.insert(layerCluster);
-	++cluster_index;
-	return layer;
+  
+            // std::cout << "in fillLayerCluster" << std::endl;
+            const std::vector< std::pair<DetId, float> > &hf = layerCluster->hitsAndFractions();
+            std::vector<unsigned int> rhIndices;
+            int ncoreHit = 0;
+            int layer = 0;
+            int rhSeed = 0;
+            if (!fillRecHits) {
+              rhSeed = -1;
+            }
+            float maxEnergy = -1.;
+            Double_t pcavars[3];
+            unsigned hfsize=hf.size();
+  
+            for(unsigned int j = 0; j < hfsize; j++) {
+              //here we loop over detid/fraction pairs
+              float fraction = hf[j].second;
+              const DetId rh_detid = hf[j].first;
+              layer = recHitTools.getLayerWithOffset(rh_detid);
+              const HGCRecHit *hit = hitmap[rh_detid];
+              ncoreHit += int(fraction);
+    
+              double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
+              double mip=dEdXWeights[layer]*0.001; // convert in GeV
+              if (thickness > 99. && thickness < 101) 
+                mip *= invThicknessCorrection[0];
+              else if (thickness > 199 && thickness <201)
+                mip *= invThicknessCorrection[1];
+              else if (thickness > 299 && thickness <301)
+                mip *= invThicknessCorrection[2];
+              //		std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;
+    
+              if(multiClusterIndex>=0 and fraction>0 && mip > 0) {
+                pcavars[0] = recHitTools.getPosition(rh_detid).x();
+                pcavars[1] = recHitTools.getPosition(rh_detid).y();
+                pcavars[2] = recHitTools.getPosition(rh_detid).z();
+      //		  std::cout << pcavars[0] << " " << pcavars[1] << " " << pcavars[2] << std::endl;
+      //		  std::cout << " Multiplicity " << int(hit->energy()/mip) <<std::endl;
+                if(pcavars[2]!=0)
+                  for (int i=0; i<int(hit->energy()/mip); ++i)
+                    pca_->AddRow(pcavars);
+              }
+              
+    
+              if (fillRecHits) {
+                if(storedRecHits.find(rh_detid)==storedRecHits.end() ) {
+                  // std::cout << "in fillLayerCluster: RecHit not yet filled" << std::endl;
+                  // std::cout << "in fillLayerCluster: hit energy: " << hit->energy() << std::endl;
+                  // std::cout << "in fillLayerCluster: first hit energy: " << maxEnergy << std::endl;
+                  if(hit->energy() > maxEnergy) {
+                    rhSeed = rechit_index;
+                    maxEnergy = hit->energy();
+                  }
+                  rhIndices.push_back(rechit_index);
+                  fillRecHit(rh_detid, fraction, layer, cluster_index);
+                }
+                else {
+                  // need to see what to do about existing rechits in case of sharing
+                  std::cout << "RecHit already filled for different layer cluster: " << int(rh_detid) << std::endl;
+                }
+              }
+            }
+  
+            double pt = layerCluster->energy() / cosh(layerCluster->eta());
+  
+            cluster2d_eta.push_back(layerCluster->eta());
+            cluster2d_phi.push_back(layerCluster->phi());
+            cluster2d_pt.push_back(pt);
+            cluster2d_energy.push_back(layerCluster->energy());
+            cluster2d_x.push_back(layerCluster->x());
+            cluster2d_y.push_back(layerCluster->y());
+            cluster2d_z.push_back(layerCluster->z());
+            cluster2d_layer.push_back(layer);
+            cluster2d_nhitCore.push_back(ncoreHit);
+            cluster2d_nhitAll.push_back(hf.size());
+            cluster2d_multicluster.push_back(multiClusterIndex);
+            cluster2d_rechitSeed.push_back(rhSeed);
+            cluster2d_rechits.push_back(rhIndices);
+  
+            storedLayerClusters.insert(layerCluster);
+            ++cluster_index;
+            return layer;
 }
 
 
 void HGCalAnalysis::fillRecHit(const DetId& detid, const float& fraction, const unsigned int& layer, const int& cluster_index) {
-
-	// std::cout << "in fillRecHit" << std::endl;
-	int flags = 0x0;
-	if (fraction>0. && fraction<1.)
-		flags = 0x1;
-	else if(fraction<0.)
-		flags = 0x3;
-	else if(fraction==0.)
-		flags = 0x2;
-	const HGCRecHit *hit = hitmap[detid];
-
-	const GlobalPoint position = recHitTools.getPosition(detid);
-	const unsigned int wafer = ( DetId::Forward == DetId(detid).det() ? recHitTools.getWafer(detid) : std::numeric_limits<unsigned int>::max() );
-	const unsigned int cell  = ( DetId::Forward == DetId(detid).det() ? recHitTools.getCell(detid) :  std::numeric_limits<unsigned int>::max() );
-	const double cellThickness = ( DetId::Forward == DetId(detid).det() ? recHitTools.getSiThickness(detid) : std::numeric_limits<std::float_t>::max() );
-	const bool isHalfCell = recHitTools.isHalfCell(detid);
-	const double eta = recHitTools.getEta(position, vz);
-	const double phi = recHitTools.getPhi(position);
-	const double pt = recHitTools.getPt(position, hit->energy(), vz);
-
-
-	// fill the vectors
-	rechit_eta.push_back(eta);
-	rechit_phi.push_back(phi);
-	rechit_pt.push_back(pt);
-	rechit_energy.push_back(hit->energy());
-	rechit_layer.push_back(layer);
-	rechit_wafer.push_back(wafer);
-	rechit_cell.push_back(cell);
-	rechit_detid.push_back(detid);
-	rechit_x.push_back(position.x());
-	rechit_y.push_back(position.y());
-	rechit_z.push_back(position.z());
-	rechit_time.push_back(hit->time());
-	rechit_thickness.push_back(cellThickness);
-	rechit_isHalf.push_back(isHalfCell);
-	rechit_flags.push_back(flags);
-	rechit_cluster2d.push_back(cluster_index);
-
-	storedRecHits.insert(detid);
-	++rechit_index;
-
+  
+            // std::cout << "in fillRecHit" << std::endl;
+        int flags = 0x0;
+        if (fraction>0. && fraction<1.)
+                flags = 0x1;
+        else if(fraction<0.)
+                flags = 0x3;
+        else if(fraction==0.)
+                flags = 0x2;
+        const HGCRecHit *hit = hitmap[detid];
+            
+        const GlobalPoint position = recHitTools.getPosition(detid);
+        const unsigned int wafer = ( DetId::Forward == DetId(detid).det() ? recHitTools.getWafer(detid) : std::numeric_limits<unsigned int>::max() );
+        const unsigned int cell  = ( DetId::Forward == DetId(detid).det() ? recHitTools.getCell(detid) :  std::numeric_limits<unsigned int>::max() );
+        const double cellThickness = ( DetId::Forward == DetId(detid).det() ? recHitTools.getSiThickness(detid) : std::numeric_limits<std::float_t>::max() );
+        const bool isHalfCell = recHitTools.isHalfCell(detid);
+        const double eta = recHitTools.getEta(position, vz);
+        const double phi = recHitTools.getPhi(position);
+        const double pt = recHitTools.getPt(position, hit->energy(), vz);
+        
+  
+        // fill the vectors
+        rechit_eta.push_back(eta);
+        rechit_phi.push_back(phi);
+        rechit_pt.push_back(pt);
+        rechit_energy.push_back(hit->energy());
+        rechit_layer.push_back(layer);
+        rechit_wafer.push_back(wafer);
+        rechit_cell.push_back(cell);
+        rechit_detid.push_back(detid);
+        rechit_x.push_back(position.x());
+        rechit_y.push_back(position.y());
+        rechit_z.push_back(position.z());
+        rechit_time.push_back(hit->time());
+        rechit_thickness.push_back(cellThickness);
+        rechit_isHalf.push_back(isHalfCell);
+        rechit_flags.push_back(flags);
+        rechit_cluster2d.push_back(cluster_index);
+        
+        storedRecHits.insert(detid);
+        ++rechit_index;
+        
 }
 
 void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar, 
                                  math::XYZVector& axis, float & sigu, float &sigv, float radius)  {
-  bool recomputePCA=false;
-  sigu = 0.;
-  sigv = 0.;
-  float radius2 = radius*radius;
+        bool recomputePCA=false;
+        sigu = 0.;
+        sigv = 0.;
+        float radius2 = radius*radius;
+  
+        pca_.reset(new TPrincipal(3,"D"));
+        Double_t pcavars[3];
 
-  pca_.reset(new TPrincipal(3,"D"));
-  Double_t pcavars[3];
+        //  std::cout << " Barycenter " << bar << " " << axis << std::endl;
+        // First build the rotation matrix
+        math::XYZVector mainAxis(axis);
+        mainAxis.unit();
+        math::XYZVector phiAxis(bar.x(),bar.y(),0);
+        math::XYZVector udir(mainAxis.Cross(phiAxis));
+        udir.unit();
+        Transform3D trans(Point(bar),Point(bar+mainAxis),Point(bar+udir),
+                          Point(0,0,0), Point(0.,0.,1.), Point(1.,0.,0.));
 
-  //  std::cout << " Barycenter " << bar << " " << axis << std::endl;
-  // First build the rotation matrix
-  math::XYZVector mainAxis(axis);
-  mainAxis.unit();
-  math::XYZVector phiAxis(bar.x(),bar.y(),0);
-  math::XYZVector udir(mainAxis.Cross(phiAxis));
-  udir.unit();
-  Transform3D trans(Point(bar),Point(bar+mainAxis),Point(bar+udir),
-		    Point(0,0,0), Point(0.,0.,1.), Point(1.,0.,0.));
-
-  //  unsigned nhit=0;
-  float etot=0;
-  for(reco::HGCalMultiCluster::component_iterator it = cluster.begin();
-      it!=cluster.end(); it++) {
-    const std::vector< std::pair<DetId, float> > &hf = (*it)->hitsAndFractions();
-    unsigned hfsize=hf.size();
-    if(hfsize==0) continue;
-    unsigned int layer = recHitTools.getLayerWithOffset(hf[0].first);
-    if(layer>28) continue;
+        //  unsigned nhit=0;
+        float etot=0;
+        for(reco::HGCalMultiCluster::component_iterator it = cluster.begin();
+            it!=cluster.end(); it++) {
+            const std::vector< std::pair<DetId, float> > &hf = (*it)->hitsAndFractions();
+            unsigned hfsize=hf.size();
+            if(hfsize==0) continue;
+            unsigned int layer = recHitTools.getLayerWithOffset(hf[0].first);
+            if(layer>28) continue;
 
 
-    for(unsigned int j = 0; j < hfsize; j++) {
-      const DetId rh_detid = hf[j].first;
-      const HGCRecHit *hit = hitmap[rh_detid];
-      float fraction = hf[j].second;
-      if(fraction>0)
-	{
-	  math::XYZPoint local = trans(Point(recHitTools.getPosition(rh_detid)));
+            for(unsigned int j = 0; j < hfsize; j++) {
+                const DetId rh_detid = hf[j].first;
+                const HGCRecHit *hit = hitmap[rh_detid];
+                float fraction = hf[j].second;
+                if(fraction>0)
+                  {
+                    math::XYZPoint local = trans(Point(recHitTools.getPosition(rh_detid)));
           
-	  if(local.Perp2() > 25) continue;
+                    if(local.Perp2() > 25) continue;
           
-	  if(local.Perp2() < radius2 ) {
-	    sigu += local.x()*local.x()*hit->energy();
-	    sigv += local.y()*local.y()*hit->energy();
-            etot += hit->energy();
-            //	    ++nhit;
-          }
-	  if (!recomputePCA) continue;
-          double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
-	  double mip=dEdXWeights[layer]*0.001; // convert in GeV
-	  if (thickness > 99. && thickness < 101) 
-	    mip *= invThicknessCorrection[0];
-	  else if (thickness > 199 && thickness <201)
-	    mip *= invThicknessCorrection[1];
-	  else if (thickness > 299 && thickness <301)
-	    mip *= invThicknessCorrection[2];
+                    if(local.Perp2() < radius2 ) {
+                      sigu += local.x()*local.x()*hit->energy();
+                      sigv += local.y()*local.y()*hit->energy();
+                      etot += hit->energy();
+                      //	    ++nhit;
+                    }
+                    if (!recomputePCA) continue;
+                    double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
+                    double mip=dEdXWeights[layer]*0.001; // convert in GeV
+                    if (thickness > 99. && thickness < 101) 
+                        mip *= invThicknessCorrection[0];
+                    else if (thickness > 199 && thickness <201)
+                        mip *= invThicknessCorrection[1];
+                    else if (thickness > 299 && thickness <301)
+                        mip *= invThicknessCorrection[2];
 
-	  //		std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;	    
+                    // std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;	    
 	  
-	  pcavars[0] = recHitTools.getPosition(rh_detid).x();
-	  pcavars[1] = recHitTools.getPosition(rh_detid).y();
-	  pcavars[2] = recHitTools.getPosition(rh_detid).z();
-	  if(pcavars[2]!=0){
-	    for (int i=0; i<int(hit->energy()/mip); ++i)
-	      pca_->AddRow(pcavars);
-	  }
-	}
-    }    
-  }
-  if(etot > 0.) {
-    sigu=sigu/etot;
-    sigv=sigv/etot;
-  }
-  sigu=std::sqrt(sigu);
-  sigv=std::sqrt(sigv);
-
-  if (recomputePCA) {
-    pca_->MakePrincipals();
+                    pcavars[0] = recHitTools.getPosition(rh_detid).x();
+                    pcavars[1] = recHitTools.getPosition(rh_detid).y();
+                    pcavars[2] = recHitTools.getPosition(rh_detid).z();
+                    if(pcavars[2]!=0){
+                        for (int i=0; i<int(hit->energy()/mip); ++i)
+                            pca_->AddRow(pcavars);
+                    }
+                  }
+            }    
+        }
+        if(etot > 0.) {
+            sigu=sigu/etot;
+            sigv=sigv/etot;
+        }
+        sigu=std::sqrt(sigu);
+        sigv=std::sqrt(sigv);
+  
+        if (recomputePCA) {
+            pca_->MakePrincipals();
     
-    const TMatrixD& eigens = *(pca_->GetEigenVectors());
-    math::XYZVector newaxis(eigens(0,0),eigens(1,0),eigens(2,0));
-    if( newaxis.z()*bar.z() < 0.0 ) {
-      newaxis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
-    }
-    axis = newaxis;
-    const TVectorD means = *(pca_->GetMeanValues());
-    bar = math::XYZPoint(means[0],means[1],means[2]);
-  }
+            const TMatrixD& eigens = *(pca_->GetEigenVectors());
+            math::XYZVector newaxis(eigens(0,0),eigens(1,0),eigens(2,0));
+            if( newaxis.z()*bar.z() < 0.0 ) {
+              newaxis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
+            }
+            axis = newaxis;
+            const TVectorD means = *(pca_->GetMeanValues());
+            bar = math::XYZPoint(means[0],means[1],means[2]);
+        }
 }
 
 
@@ -1482,9 +1484,9 @@ void
 HGCalAnalysis::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 	//The following says we do not know what parameters are allowed so do no validation
 	// Please change this to state exactly what you do use, even if it is no parameters
-	edm::ParameterSetDescription desc;
-	desc.setUnknown();
-	descriptions.addDefault(desc);
+        edm::ParameterSetDescription desc;
+        desc.setUnknown();
+        descriptions.addDefault(desc);
 }
 
 /*

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -74,7 +74,7 @@ explicit HGCalAnalysis(const edm::ParameterSet&);
 ~HGCalAnalysis();
 
 static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-virtual void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
+ virtual void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
 virtual void endRun(edm::Run const& iEvent, edm::EventSetup const&) override;
 
 private:
@@ -299,18 +299,18 @@ HGCalAnalysis::HGCalAnalysis() {
 }
 
 HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
-        readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
-        readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
-        layerClusterPtThreshold(iConfig.getParameter<double>("layerClusterPtThreshold")),
-        propagationPtThreshold(iConfig.getUntrackedParameter<double>("propagationPtThreshold",3.0)),
-        detector(iConfig.getParameter<std::string >("detector")),
-        rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
-        particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
-        dEdXWeights(iConfig.getParameter<std::vector<double> >("dEdXWeights")),
-        invThicknessCorrection({1./1.132,1./1.092,1./1.084}),
-        pca_(new TPrincipal(3,"D"))
+       readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
+       readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
+       layerClusterPtThreshold(iConfig.getParameter<double>("layerClusterPtThreshold")),
+       propagationPtThreshold(iConfig.getUntrackedParameter<double>("propagationPtThreshold",3.0)),
+       detector(iConfig.getParameter<std::string >("detector")),
+       rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
+       particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
+       dEdXWeights(iConfig.getParameter<std::vector<double> >("dEdXWeights")),
+       invThicknessCorrection({1./1.132,1./1.092,1./1.084}),
+       pca_(new TPrincipal(3,"D"))
 {
-        // now do what ever initialization is needed
+       // now do what ever initialization is needed
         mySimEvent = new FSimEvent(particleFilter);
   
         if(detector=="all") {
@@ -1132,8 +1132,8 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	  
 	  if (it_track->pt()>= propagationPtThreshold) {
 	    
-	    // Define error matrix
-	    ROOT::Math::SMatrixIdentity id;
+	      // Define error matrix
+	      ROOT::Math::SMatrixIdentity id;
 	    AlgebraicSymMatrix55 C(id);
 	    C *= 0.01;
 	    CurvilinearTrajectoryError err(C);

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -211,9 +211,6 @@ std::vector<float> multiclus_eigenSig2;
 std::vector<float> multiclus_eigenSig3;
 std::vector<float> multiclus_siguu;
 std::vector<float> multiclus_sigvv;
-// std::vector<std::vector<float> >multiclus_sigrad;
-// std::vector<std::vector<float> >multiclus_radsiguu;
-// std::vector<std::vector<float> >multiclus_radsigvv;
 std::vector<int> multiclus_firstLay;
 std::vector<int> multiclus_lastLay;
 std::vector<int> multiclus_NLay;
@@ -438,9 +435,6 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("multiclus_eigenSig3", &multiclus_eigenSig3);
 	t->Branch("multiclus_siguu", &multiclus_siguu);
 	t->Branch("multiclus_sigvv", &multiclus_sigvv);
-	// t->Branch("multiclus_sigrad", &multiclus_sigrad);
-	// t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
-	// t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
 	t->Branch("multiclus_firstLay",&multiclus_firstLay);
 	t->Branch("multiclus_lastLay",&multiclus_lastLay);
 	t->Branch("multiclus_NLay",&multiclus_NLay);
@@ -596,9 +590,6 @@ void HGCalAnalysis::clearVariables() {
 	multiclus_eigenSig3.clear();
 	multiclus_siguu.clear();
 	multiclus_sigvv.clear();
-	// multiclus_sigrad.clear();
-	// multiclus_radsiguu.clear();
-	// multiclus_radsigvv.clear();
 	multiclus_firstLay.clear();
 	multiclus_lastLay.clear();
 	multiclus_NLay.clear();
@@ -940,10 +931,6 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 			multiclus_eigenSig3.push_back(-2.);
 			multiclus_siguu.push_back(-2.);
 			multiclus_sigvv.push_back(-2.);
-			// std::vector<float> dummy;
-			// multiclus_sigrad.push_back(dummy);
-			// multiclus_radsiguu.push_back(dummy);
-			// multiclus_radsigvv.push_back(dummy);
 			continue;
 		  }
 		pca_->MakePrincipals();
@@ -957,24 +944,11 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  	axis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
 		}
 		float sigu,sigv;
-		// std::vector<float> radsiguu;
-		// std::vector<float> radsigvv;
-		// std::vector<float> sigrad;
-
-				//		for(float radius=1.;  radius<=10.; radius+=1.) {
 		float radius=5.;
 
 		computeWidth(multiClusters[i],barycenter,axis,sigu,sigv,radius);
-		// sigrad.push_back(radius);
-		// radsiguu.push_back(sigu);
-		// radsigvv.push_back(sigv);
-		// not elegant, but keep it because of the commented loop above
-		if (radius>4.9 && radius < 5.1) {
-		 	multiclus_siguu.push_back(sigu);
-			multiclus_sigvv.push_back(sigv);
-				  //                }
-		}
-
+		multiclus_siguu.push_back(sigu);
+	  multiclus_sigvv.push_back(sigv);
 		multiclus_pcaAxisX.push_back(axis.x());
 		multiclus_pcaAxisY.push_back(axis.y());
 		multiclus_pcaAxisZ.push_back(axis.z());
@@ -987,9 +961,6 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		multiclus_eigenSig1.push_back(sigmas(0));
 		multiclus_eigenSig2.push_back(sigmas(1));
 		multiclus_eigenSig3.push_back(sigmas(2));
-		// multiclus_sigrad.push_back(sigrad);
-		// multiclus_radsiguu.push_back(radsiguu);
-		// multiclus_radsigvv.push_back(radsigvv);
 	}
 
 	// Fills the additional 2d layers

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -88,7 +88,7 @@ void clearVariables();
 
 void retrieveLayerPositions(const edm::EventSetup&, unsigned layers);
 
-void computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar, 
+void computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar,
 				  math::XYZVector& axis, float & sigu, float & sigv,float radius=5);
 
 
@@ -211,9 +211,9 @@ std::vector<float> multiclus_eigenSig2;
 std::vector<float> multiclus_eigenSig3;
 std::vector<float> multiclus_siguu;
 std::vector<float> multiclus_sigvv;
-std::vector<std::vector<float> >multiclus_sigrad;
-std::vector<std::vector<float> >multiclus_radsiguu;
-std::vector<std::vector<float> >multiclus_radsigvv;
+// std::vector<std::vector<float> >multiclus_sigrad;
+// std::vector<std::vector<float> >multiclus_radsiguu;
+// std::vector<std::vector<float> >multiclus_radsigvv;
 std::vector<int> multiclus_firstLay;
 std::vector<int> multiclus_lastLay;
 std::vector<int> multiclus_NLay;
@@ -312,7 +312,7 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 {
 	// now do what ever initialization is needed
 	mySimEvent = new FSimEvent(particleFilter);
-  
+
 	if(detector=="all") {
 		_recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
 		_recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
@@ -343,12 +343,12 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	_pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
 	_multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
 	_tracks = consumes<std::vector<reco::Track> >(edm::InputTag("generalTracks"));
-  
-  
+
+
 	usesResource(TFileService::kSharedResource);
 	edm::Service<TFileService> fs;
 	fs->make<TH1F>("total", "total", 100, 0, 5.);
-	
+
 	t = fs->make<TTree>("hgc","hgc");
 
 	// event info
@@ -358,7 +358,7 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("vtx_x", &vtx_x);
 	t->Branch("vtx_y", &vtx_y);
 	t->Branch("vtx_z", &vtx_z);
-	
+
 	t->Branch("genpart_eta", &genpart_eta);
 	t->Branch("genpart_phi", &genpart_phi);
 	t->Branch("genpart_pt", &genpart_pt);
@@ -374,7 +374,7 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("genpart_posx", &genpart_posx);
 	t->Branch("genpart_posy", &genpart_posy);
 	t->Branch("genpart_posz", &genpart_posz);
-	
+
 	////////////////////
 	// RecHits
 	// associated to layer clusters
@@ -424,12 +424,12 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("multiclus_slopeY", &multiclus_slopeY);
 	t->Branch("multiclus_cluster2d", &multiclus_cluster2d);
 	t->Branch("multiclus_cl2dSeed", &multiclus_cl2dSeed);
-	t->Branch("multiclus_pcaAxisX", &multiclus_pcaAxisX); 
-	t->Branch("multiclus_pcaAxisY", &multiclus_pcaAxisY); 
+	t->Branch("multiclus_pcaAxisX", &multiclus_pcaAxisX);
+	t->Branch("multiclus_pcaAxisY", &multiclus_pcaAxisY);
 	t->Branch("multiclus_pcaAxisZ", &multiclus_pcaAxisZ);
-	t->Branch("multiclus_pcaPosX", &multiclus_pcaPosX);  
-	t->Branch("multiclus_pcaPosY", &multiclus_pcaPosY);  
-	t->Branch("multiclus_pcaPosZ", &multiclus_pcaPosZ);  
+	t->Branch("multiclus_pcaPosX", &multiclus_pcaPosX);
+	t->Branch("multiclus_pcaPosY", &multiclus_pcaPosY);
+	t->Branch("multiclus_pcaPosZ", &multiclus_pcaPosZ);
 	t->Branch("multiclus_eigenVal1", &multiclus_eigenVal1);
 	t->Branch("multiclus_eigenVal2", &multiclus_eigenVal2);
 	t->Branch("multiclus_eigenVal3", &multiclus_eigenVal3);
@@ -438,14 +438,14 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("multiclus_eigenSig3", &multiclus_eigenSig3);
 	t->Branch("multiclus_siguu", &multiclus_siguu);
 	t->Branch("multiclus_sigvv", &multiclus_sigvv);
-	t->Branch("multiclus_sigrad", &multiclus_sigrad);
-	t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
-	t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
+	// t->Branch("multiclus_sigrad", &multiclus_sigrad);
+	// t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
+	// t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
 	t->Branch("multiclus_firstLay",&multiclus_firstLay);
 	t->Branch("multiclus_lastLay",&multiclus_lastLay);
 	t->Branch("multiclus_NLay",&multiclus_NLay);
-	
-	
+
+
 	////////////////////
 	// sim clusters
 	//
@@ -459,8 +459,8 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("simcluster_layers", &simcluster_layers);
 	t->Branch("simcluster_wafers", &simcluster_wafers);
 	t->Branch("simcluster_cells", &simcluster_cells);
-	
-	
+
+
 	////////////////////
 	// PF clusters
 	//
@@ -468,8 +468,8 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("pfcluster_phi", &pfcluster_phi);
 	t->Branch("pfcluster_pt", &pfcluster_pt);
 	t->Branch("pfcluster_energy", &pfcluster_energy);
-	
-	
+
+
 	////////////////////
 	// calo particles
 	//
@@ -492,11 +492,11 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
 	t->Branch("track_posx", &track_posx);
 	t->Branch("track_posy", &track_posy);
 	t->Branch("track_posz", &track_posz);
-		
+
 }
 HGCalAnalysis::~HGCalAnalysis()
 {
-  
+
 		// do anything here that needs to be done at desctruction time
 	// (e.g. close files, deallocate resources etc.)
 
@@ -582,12 +582,12 @@ void HGCalAnalysis::clearVariables() {
 	multiclus_slopeY.clear();
 	multiclus_cluster2d.clear();
 	multiclus_cl2dSeed.clear();
-	multiclus_pcaAxisX.clear(); 	
-	multiclus_pcaAxisY.clear(); 
-	multiclus_pcaAxisZ.clear(); 
-	multiclus_pcaPosX.clear();  
-	multiclus_pcaPosY.clear();  
-	multiclus_pcaPosZ.clear();  
+	multiclus_pcaAxisX.clear();
+	multiclus_pcaAxisY.clear();
+	multiclus_pcaAxisZ.clear();
+	multiclus_pcaPosX.clear();
+	multiclus_pcaPosY.clear();
+	multiclus_pcaPosZ.clear();
 	multiclus_eigenVal1.clear();
 	multiclus_eigenVal2.clear();
 	multiclus_eigenVal3.clear();
@@ -596,9 +596,9 @@ void HGCalAnalysis::clearVariables() {
 	multiclus_eigenSig3.clear();
 	multiclus_siguu.clear();
 	multiclus_sigvv.clear();
-	multiclus_sigrad.clear();
-	multiclus_radsiguu.clear();
-	multiclus_radsigvv.clear();
+	// multiclus_sigrad.clear();
+	// multiclus_radsiguu.clear();
+	// multiclus_radsigvv.clear();
 	multiclus_firstLay.clear();
 	multiclus_lastLay.clear();
 	multiclus_NLay.clear();
@@ -768,7 +768,7 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 			}
 		}
 	} else
-	{	
+	{
 		unsigned int npart = mySimEvent->nTracks();
 		for (unsigned int i=0; i<npart; ++i) {
 			std::vector<float> xp,yp,zp;
@@ -792,7 +792,7 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 					if (result==2 && vtx.Rho()> 25) {
 						reachedEE=2;
 						double dpt=0;
-						
+
 						for(int i=0; i<myTrack.nDaughters(); ++i)
 						  	dpt+=myTrack.daughter(i).momentum().pt();
 						if(abs(myTrack.type())==11)
@@ -802,7 +802,7 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 				}
 				else // in that case we propagate only to the first layers
 				  	nlayers=1;
-				
+
 				for(unsigned il=0; il<nlayers; ++il) {
 					myPropag.setPropagationConditions(140,layerPositions[il],false);
 					if(il>0) // set PID 22 for a straight-line extrapolation after the 1st layer
@@ -815,10 +815,10 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 				}
 			}
 			else
-		  	{	
+		  	{
 				vtx = myTrack.endVertex().position();
 			}
-			
+
 			// fill branches
 			genpart_eta.push_back(myTrack.momentum().eta());
 			genpart_phi.push_back(myTrack.momentum().phi());
@@ -907,7 +907,7 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 			if((*it)->energy() > (*(it+cl2dSeed))->energy()) cl2dSeed = it - multiClusters[i].begin();
 			cl2dIndices.push_back(cluster_index);
 			int layer = fillLayerCluster(*it, true, i);
-			layers.insert(layer);			
+			layers.insert(layer);
 		}
 
 		double pt = multiClusters[i].energy() / cosh(multiClusters[i].eta());
@@ -940,10 +940,10 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 			multiclus_eigenSig3.push_back(-2.);
 			multiclus_siguu.push_back(-2.);
 			multiclus_sigvv.push_back(-2.);
-			std::vector<float> dummy;
-			multiclus_sigrad.push_back(dummy);
-			multiclus_radsiguu.push_back(dummy);
-			multiclus_radsigvv.push_back(dummy);
+			// std::vector<float> dummy;
+			// multiclus_sigrad.push_back(dummy);
+			// multiclus_radsiguu.push_back(dummy);
+			// multiclus_radsigvv.push_back(dummy);
 			continue;
 		  }
 		pca_->MakePrincipals();
@@ -957,17 +957,17 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  	axis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
 		}
 		float sigu,sigv;
-		std::vector<float> radsiguu;
-		std::vector<float> radsigvv;
-		std::vector<float> sigrad;
+		// std::vector<float> radsiguu;
+		// std::vector<float> radsigvv;
+		// std::vector<float> sigrad;
 
 				//		for(float radius=1.;  radius<=10.; radius+=1.) {
 		float radius=5.;
-		
+
 		computeWidth(multiClusters[i],barycenter,axis,sigu,sigv,radius);
-		sigrad.push_back(radius);
-		radsiguu.push_back(sigu);
-		radsigvv.push_back(sigv);
+		// sigrad.push_back(radius);
+		// radsiguu.push_back(sigu);
+		// radsigvv.push_back(sigv);
 		// not elegant, but keep it because of the commented loop above
 		if (radius>4.9 && radius < 5.1) {
 		 	multiclus_siguu.push_back(sigu);
@@ -987,9 +987,9 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		multiclus_eigenSig1.push_back(sigmas(0));
 		multiclus_eigenSig2.push_back(sigmas(1));
 		multiclus_eigenSig3.push_back(sigmas(2));
-		multiclus_sigrad.push_back(sigrad);
-		multiclus_radsiguu.push_back(radsiguu);
-		multiclus_radsigvv.push_back(radsigvv);
+		// multiclus_sigrad.push_back(sigrad);
+		// multiclus_radsiguu.push_back(radsiguu);
+		// multiclus_radsigvv.push_back(radsigvv);
 	}
 
 	// Fills the additional 2d layers
@@ -1083,17 +1083,17 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		simcluster_cells.push_back(cells);
 
 	} // end loop over simClusters
-	
+
 	// loop over pfClusters
 	for (std::vector<reco::PFCluster>::const_iterator it_pfClus = pfClusters.begin(); it_pfClus != pfClusters.end(); ++it_pfClus) {
-	  
+
 	  	pfcluster_eta.push_back(it_pfClus->eta());
 	  	pfcluster_phi.push_back(it_pfClus->phi());
 	  	pfcluster_pt.push_back(it_pfClus->pt());
 	  	pfcluster_energy.push_back(it_pfClus->energy());
-	  
+
 	} // end loop over pfClusters
-	
+
 	// loop over caloParticles
 	if (readCaloParticles) {
 	  	for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles->begin(); it_caloPart != caloParticles->end(); ++it_caloPart) {
@@ -1102,58 +1102,58 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 			for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
 		  		simClusterIndex.push_back((*it_sc).key());
 			}
-		
+
 			calopart_eta.push_back(it_caloPart->eta());
 			calopart_phi.push_back(it_caloPart->phi());
 			calopart_pt.push_back(it_caloPart->pt());
 			calopart_energy.push_back(it_caloPart->energy());
 			calopart_simEnergy.push_back(it_caloPart->simEnergy());
 			calopart_simClusterIndex.push_back(simClusterIndex);
-		
+
 	  	} // end loop over caloParticles
 	}
-	
+
 	// loop over tracks
-	
+
 	//  random = new RandomEngineAndDistribution(iEvent.streamID());
-	
+
 	// prepare for RK propagation
 	defaultRKPropagator::Product prod( aField, alongMomentum, 5.e-5);
 	auto & RKProp = prod.propagator;
-	
-	
+
+
 	for (std::vector<reco::Track>::const_iterator it_track = tracks.begin(); it_track != tracks.end(); ++it_track) {
-	  
+
 	  	if (!it_track->quality(reco::Track::highPurity)) continue;
-	  
+
 	 	double energy = it_track->pt() * cosh(it_track->eta());
-	  
+
 	  	//save info about reconstructed tracks propoagation to hgcal layers (ony for pt>propagationPtThreshold tracks)
 	  	std::vector<float> xp,yp,zp;
-	  
+
 	  	if (it_track->pt()>= propagationPtThreshold) {
-		
+
 			 // Define error matrix
 			ROOT::Math::SMatrixIdentity id;
 			AlgebraicSymMatrix55 C(id);
 			C *= 0.01;
 			CurvilinearTrajectoryError err(C);
 			typedef TrajectoryStateOnSurface TSOS;
-			
+
 			GlobalPoint startingPosition(it_track->vx(),it_track->vy(),it_track->vz());
 			GlobalVector startingMomentum(it_track->px(),it_track->py(),it_track->pz());
-			
+
 			Plane::PlanePointer startingPlane = Plane::build( Plane::PositionType (it_track->vx(),it_track->vy(),it_track->vz()), Plane::RotationType () );
-			
+
 			TSOS startingStateP(GlobalTrajectoryParameters(startingPosition,startingMomentum, it_track->charge(), aField), err, *startingPlane);
-			
+
 			for(unsigned il=0; il<layerPositions.size(); ++il) {
 			  	float xp_curr=0;
 			  	float yp_curr=0;
 			  	float zp_curr=0;
-			  
+
 			  	for (int zside = -1; zside <=1; zside+=2) {
-				// clearly try both sides	
+				// clearly try both sides
 			  		Plane::PlanePointer endPlane = Plane::build( Plane::PositionType (0,0,zside*layerPositions[il]), Plane::RotationType());
 			  		try{
 					/*
@@ -1167,20 +1167,20 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 				  			xp_curr=trackStateP.globalPosition().x();
 				  			yp_curr=trackStateP.globalPosition().y();
 				  			zp_curr=trackStateP.globalPosition().z();
-				  
+
 				  			// std::cout << "Succesfully finished Positive track propagation  -------------- with RK: " << trackStateP.globalPosition() << std::endl;
 						}
-		     		}		
+		     		}
 			  		catch (...) {
 						std::cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << std::endl;
 			  		}
-				}	
+				}
 				xp.push_back(xp_curr);
 				yp.push_back(yp_curr);
 				zp.push_back(zp_curr);
 			} // closes loop on layers
 		} // closes conditions pt>3
-	  
+
 		// save info in tree
 		track_pt.push_back(it_track->pt());
 		track_pt.push_back(it_track->eta());
@@ -1190,33 +1190,33 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		track_posx.push_back(xp);
 		track_posy.push_back(yp);
 		track_posz.push_back(zp);
-	  
+
 	} // end loop over tracks
-	
+
 	ev_event = iEvent.id().event();
 	ev_lumi = iEvent.id().luminosityBlock();
 	ev_run = iEvent.id().run();
-	
+
 	vtx_x = vx;
 	vtx_y = vy;
 	vtx_z = vz;
-	
+
 	t->Fill();
 }
 
 void HGCalAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
-  
+
 		edm::ESHandle < HepPDT::ParticleDataTable > pdt;
 		es.getData(pdt);
 		mySimEvent->initializePdt(&(*pdt));
-  
+
 		retrieveLayerPositions(es,52);
-  
+
 		edm::ESHandle<MagneticField> magfield;
 		es.get<IdealMagneticFieldRecord>().get(magfield);
-  
+
 		aField=&(*magfield);
-  
+
 }
 
 void HGCalAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {
@@ -1240,7 +1240,7 @@ HGCalAnalysis::endJob()
 void HGCalAnalysis::retrieveLayerPositions(const edm::EventSetup& es, unsigned layers)
 {
   	recHitTools.getEventSetup(es);
-  
+
   	DetId id;
   	for(unsigned ilayer=1; ilayer<=layers; ++ilayer) {
 		if (ilayer<=28) id=HGCalDetId(ForwardSubdetector::HGCEE,1,ilayer,1,50,1);
@@ -1249,14 +1249,14 @@ void HGCalAnalysis::retrieveLayerPositions(const edm::EventSetup& es, unsigned l
 		const GlobalPoint pos = recHitTools.getPosition(id);
 		//  std::cout << "GEOM " ;
 		//	std::cout << " layer " << ilayer << " " << pos.z() << std::endl;
-	
+
 		layerPositions.push_back(pos.z());
   }
 }
 
 
 int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerCluster, const bool& fillRecHits, const int& multiClusterIndex) {
-  
+
 	// std::cout << "in fillLayerCluster" << std::endl;
 	const std::vector< std::pair<DetId, float> > &hf = layerCluster->hitsAndFractions();
 	std::vector<unsigned int> rhIndices;
@@ -1280,7 +1280,7 @@ int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerClus
 
 	  	double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
 	  	double mip=dEdXWeights[layer]*0.001; // convert in GeV
-	  	if (thickness > 99. && thickness < 101) 
+	  	if (thickness > 99. && thickness < 101)
 			mip *= invThicknessCorrection[0];
 	  	else if (thickness > 199 && thickness <201)
 			mip *= invThicknessCorrection[1];
@@ -1297,8 +1297,8 @@ int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerClus
 		if(pcavars[2]!=0)
 		  	for (int i=0; i<int(hit->energy()/mip); ++i)
 				pca_->AddRow(pcavars);
-	}	
-	  
+	}
+
 
 	 if (fillRecHits) {
 		if(storedRecHits.find(rh_detid)==storedRecHits.end() ) {
@@ -1308,14 +1308,14 @@ int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerClus
 		  	if(hit->energy() > maxEnergy) {
 				rhSeed = rechit_index;
 				maxEnergy = hit->energy();
-		  	}	
+		  	}
 		  	rhIndices.push_back(rechit_index);
 		  	fillRecHit(rh_detid, fraction, layer, cluster_index);
-		}	
+		}
 		else {
 		  // need to see what to do about existing rechits in case of sharing
 		 std::cout << "RecHit already filled for different layer cluster: " << int(rh_detid) << std::endl;
-		}	
+		}
 	  }
 	}
 
@@ -1342,7 +1342,7 @@ int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerClus
 
 
 void HGCalAnalysis::fillRecHit(const DetId& detid, const float& fraction, const unsigned int& layer, const int& cluster_index) {
-  
+
 		// std::cout << "in fillRecHit" << std::endl;
 	int flags = 0x0;
 	if (fraction>0. && fraction<1.)
@@ -1352,7 +1352,7 @@ void HGCalAnalysis::fillRecHit(const DetId& detid, const float& fraction, const 
 	else if(fraction==0.)
 			flags = 0x2;
 	const HGCRecHit *hit = hitmap[detid];
-		
+
 	const GlobalPoint position = recHitTools.getPosition(detid);
 	const unsigned int wafer = ( DetId::Forward == DetId(detid).det() ? recHitTools.getWafer(detid) : std::numeric_limits<unsigned int>::max() );
 	const unsigned int cell  = ( DetId::Forward == DetId(detid).det() ? recHitTools.getCell(detid) :  std::numeric_limits<unsigned int>::max() );
@@ -1361,7 +1361,7 @@ void HGCalAnalysis::fillRecHit(const DetId& detid, const float& fraction, const 
 	const double eta = recHitTools.getEta(position, vz);
 	const double phi = recHitTools.getPhi(position);
 	const double pt = recHitTools.getPt(position, hit->energy(), vz);
-	
+
 
 	// fill the vectors
 	rechit_eta.push_back(eta);
@@ -1380,13 +1380,13 @@ void HGCalAnalysis::fillRecHit(const DetId& detid, const float& fraction, const 
 	rechit_isHalf.push_back(isHalfCell);
 	rechit_flags.push_back(flags);
 	rechit_cluster2d.push_back(cluster_index);
-	
+
 	storedRecHits.insert(detid);
 	++rechit_index;
-		
+
 }
 
-void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar, 
+void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar,
 								 math::XYZVector& axis, float & sigu, float &sigv, float radius)  {
 		bool recomputePCA=false;
 		sigu = 0.;
@@ -1402,10 +1402,16 @@ void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::X
 		mainAxis.unit();
 		math::XYZVector phiAxis(bar.x(),bar.y(),0);
 		math::XYZVector udir(mainAxis.Cross(phiAxis));
-		udir.unit();
+		udir = udir.unit();
+    // std::cout << " udir "<< udir.unit() << std::endl;
 		Transform3D trans(Point(bar),Point(bar+mainAxis),Point(bar+udir),
 						  Point(0,0,0), Point(0.,0.,1.), Point(1.,0.,0.));
-
+    // Point testPoint(bar+udir);
+    // Point localTestPoint=trans(testPoint);
+    // std::cout << " bar " << bar << std::endl;
+    // std::cout << " udir "<< udir << std::endl;
+    // std::cout << "TestPoint g " << testPoint << std::endl;
+    // std::cout << "TestPoint l " << localTestPoint << std::endl;
 		//  unsigned nhit=0;
 		float etot=0;
 		for(reco::HGCalMultiCluster::component_iterator it = cluster.begin();
@@ -1424,10 +1430,10 @@ void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::X
 				if(fraction>0)
 				  {
 					math::XYZPoint local = trans(Point(recHitTools.getPosition(rh_detid)));
-		  
 					if(local.Perp2() > 25) continue;
-		  
+
 					if(local.Perp2() < radius2 ) {
+
 					  sigu += local.x()*local.x()*hit->energy();
 					  sigv += local.y()*local.y()*hit->energy();
 					  etot += hit->energy();
@@ -1436,15 +1442,15 @@ void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::X
 					if (!recomputePCA) continue;
 					double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
 					double mip=dEdXWeights[layer]*0.001; // convert in GeV
-					if (thickness > 99. && thickness < 101) 
+					if (thickness > 99. && thickness < 101)
 						mip *= invThicknessCorrection[0];
 					else if (thickness > 199 && thickness <201)
 						mip *= invThicknessCorrection[1];
 					else if (thickness > 299 && thickness <301)
 						mip *= invThicknessCorrection[2];
 
-					// std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;	    
-	  
+					// std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;
+
 					pcavars[0] = recHitTools.getPosition(rh_detid).x();
 					pcavars[1] = recHitTools.getPosition(rh_detid).y();
 					pcavars[2] = recHitTools.getPosition(rh_detid).z();
@@ -1453,7 +1459,7 @@ void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::X
 							pca_->AddRow(pcavars);
 					}
 				  }
-			}    
+			}
 		}
 		if(etot > 0.) {
 			sigu=sigu/etot;

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -89,7 +89,7 @@ void clearVariables();
 void retrieveLayerPositions(const edm::EventSetup&, unsigned layers);
 
 void computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar, 
-                  math::XYZVector& axis, float & sigu, float & sigv,float radius=5);
+				  math::XYZVector& axis, float & sigu, float & sigv,float radius=5);
 
 
 // ---------parameters ----------------------------
@@ -299,205 +299,205 @@ HGCalAnalysis::HGCalAnalysis() {
 }
 
 HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet& iConfig) :
-       readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
-       readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
-       layerClusterPtThreshold(iConfig.getParameter<double>("layerClusterPtThreshold")),
-       propagationPtThreshold(iConfig.getUntrackedParameter<double>("propagationPtThreshold",3.0)),
-       detector(iConfig.getParameter<std::string >("detector")),
-       rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
-       particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
-       dEdXWeights(iConfig.getParameter<std::vector<double> >("dEdXWeights")),
-       invThicknessCorrection({1./1.132,1./1.092,1./1.084}),
-       pca_(new TPrincipal(3,"D"))
+	readOfficialReco(iConfig.getParameter<bool>("readOfficialReco")),
+	readCaloParticles(iConfig.getParameter<bool>("readCaloParticles")),
+	layerClusterPtThreshold(iConfig.getParameter<double>("layerClusterPtThreshold")),
+	propagationPtThreshold(iConfig.getUntrackedParameter<double>("propagationPtThreshold",3.0)),
+	detector(iConfig.getParameter<std::string >("detector")),
+	rawRecHits(iConfig.getParameter<bool>("rawRecHits")),
+	particleFilter(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
+	dEdXWeights(iConfig.getParameter<std::vector<double> >("dEdXWeights")),
+	invThicknessCorrection({1./1.132,1./1.092,1./1.084}),
+	pca_(new TPrincipal(3,"D"))
 {
-       // now do what ever initialization is needed
-        mySimEvent = new FSimEvent(particleFilter);
+	// now do what ever initialization is needed
+	mySimEvent = new FSimEvent(particleFilter);
   
-        if(detector=="all") {
-                _recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
-                _recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-                _recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
-                algo = 1;
-        }else if(detector=="EM") {
-          _recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
-          algo = 2;
-        }else if(detector=="HAD") {
-          _recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-          _recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
-          algo = 3;
-        }
-        _clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
-        _simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
-        _hev = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared") );
-        if(!readOfficialReco) {
-                _vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
-                _part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
-        }
-        else {
-                _simTracks = consumes<std::vector<SimTrack> >(edm::InputTag("g4SimHits"));
-                _simVertices = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));
-        }
-        if (readCaloParticles) {
-          _caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
-        }
-        _pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
-        _multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
-        _tracks = consumes<std::vector<reco::Track> >(edm::InputTag("generalTracks"));
+	if(detector=="all") {
+		_recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
+		_recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
+		_recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
+		algo = 1;
+	}else if(detector=="EM") {
+		_recHitsEE = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCEERecHits"));
+		algo = 2;
+	}else if(detector=="HAD") {
+		_recHitsFH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
+		_recHitsBH = consumes<HGCRecHitCollection>(edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
+		algo = 3;
+	}
+	_clusters = consumes<reco::CaloClusterCollection>(edm::InputTag("hgcalLayerClusters"));
+	_simClusters = consumes<std::vector<SimCluster> >(edm::InputTag("mix","MergedCaloTruth"));
+	_hev = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared") );
+	if(!readOfficialReco) {
+		_vtx = consumes<std::vector<TrackingVertex> >(edm::InputTag("mix","MergedTrackTruth"));
+		_part = consumes<std::vector<TrackingParticle> >(edm::InputTag("mix","MergedTrackTruth"));
+	}
+	else {
+		_simTracks = consumes<std::vector<SimTrack> >(edm::InputTag("g4SimHits"));
+		_simVertices = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));
+	}
+	if (readCaloParticles) {
+	  	_caloParticles = consumes<std::vector<CaloParticle> >(edm::InputTag("mix","MergedCaloTruth"));
+	}
+	_pfClusters = consumes<std::vector<reco::PFCluster> >(edm::InputTag("particleFlowClusterHGCal"));
+	_multiClusters = consumes<std::vector<reco::HGCalMultiCluster> >(edm::InputTag("hgcalLayerClusters"));
+	_tracks = consumes<std::vector<reco::Track> >(edm::InputTag("generalTracks"));
   
   
-        usesResource(TFileService::kSharedResource);
-        edm::Service<TFileService> fs;
-        fs->make<TH1F>("total", "total", 100, 0, 5.);
-        
-        t = fs->make<TTree>("hgc","hgc");
-  
-        // event info
-        t->Branch("event", &ev_event);
-        t->Branch("lumi", &ev_lumi);
-        t->Branch("run", &ev_run);
-        t->Branch("vtx_x", &vtx_x);
-        t->Branch("vtx_y", &vtx_y);
-        t->Branch("vtx_z", &vtx_z);
-        
-        t->Branch("genpart_eta", &genpart_eta);
-        t->Branch("genpart_phi", &genpart_phi);
-        t->Branch("genpart_pt", &genpart_pt);
-        t->Branch("genpart_energy", &genpart_energy);
-        t->Branch("genpart_dvx", &genpart_dvx);
-        t->Branch("genpart_dvy", &genpart_dvy);
-        t->Branch("genpart_dvz", &genpart_dvz);
-        t->Branch("genpart_fbrem", &genpart_fbrem);
-        t->Branch("genpart_pid", &genpart_pid);
-        t->Branch("genpart_gen", &genpart_gen);
-        t->Branch("genpart_reachedEE", &genpart_reachedEE);
-        t->Branch("genpart_fromBeamPipe", &genpart_fromBeamPipe);
-        t->Branch("genpart_posx", &genpart_posx);
-        t->Branch("genpart_posy", &genpart_posy);
-        t->Branch("genpart_posz", &genpart_posz);
-        
-        ////////////////////
-        // RecHits
-        // associated to layer clusters
-        t->Branch("rechit_eta", &rechit_eta);
-        t->Branch("rechit_phi", &rechit_phi);
-        t->Branch("rechit_pt", &rechit_pt);
-        t->Branch("rechit_energy", &rechit_energy);
-        t->Branch("rechit_x", &rechit_x);
-        t->Branch("rechit_y", &rechit_y);
-        t->Branch("rechit_z", &rechit_z);
-        t->Branch("rechit_time", &rechit_time);
-        t->Branch("rechit_thickness", &rechit_thickness);
-        t->Branch("rechit_layer", &rechit_layer);
-        t->Branch("rechit_wafer", &rechit_wafer);
-        t->Branch("rechit_cell", &rechit_cell);
-        t->Branch("rechit_detid", &rechit_detid);
-        t->Branch("rechit_isHalf", &rechit_isHalf);
-        t->Branch("rechit_flags", &rechit_flags);
-        t->Branch("rechit_cluster2d", &rechit_cluster2d);
-  
-        ////////////////////
-        // layer clusters
-        //
-        t->Branch("cluster2d_eta", &cluster2d_eta);
-        t->Branch("cluster2d_phi", &cluster2d_phi);
-        t->Branch("cluster2d_pt", &cluster2d_pt);
-        t->Branch("cluster2d_energy", &cluster2d_energy);
-        t->Branch("cluster2d_x", &cluster2d_x);
-        t->Branch("cluster2d_y", &cluster2d_y);
-        t->Branch("cluster2d_z", &cluster2d_z);
-        t->Branch("cluster2d_layer", &cluster2d_layer);
-        t->Branch("cluster2d_nhitCore", &cluster2d_nhitCore);
-        t->Branch("cluster2d_nhitAll", &cluster2d_nhitAll);
-        t->Branch("cluster2d_multicluster", &cluster2d_multicluster);
-        t->Branch("cluster2d_rechits", &cluster2d_rechits);
-        t->Branch("cluster2d_rechitSeed", &cluster2d_rechitSeed);
-  
-        ////////////////////
-        // multi clusters
-        //
-        t->Branch("multiclus_eta", &multiclus_eta);
-        t->Branch("multiclus_phi", &multiclus_phi);
-        t->Branch("multiclus_pt", &multiclus_pt);
-        t->Branch("multiclus_energy", &multiclus_energy);
-        t->Branch("multiclus_z", &multiclus_z);
-        t->Branch("multiclus_slopeX", &multiclus_slopeX);
-        t->Branch("multiclus_slopeY", &multiclus_slopeY);
-        t->Branch("multiclus_cluster2d", &multiclus_cluster2d);
-        t->Branch("multiclus_cl2dSeed", &multiclus_cl2dSeed);
-        t->Branch("multiclus_pcaAxisX", &multiclus_pcaAxisX); 
-        t->Branch("multiclus_pcaAxisY", &multiclus_pcaAxisY); 
-        t->Branch("multiclus_pcaAxisZ", &multiclus_pcaAxisZ);
-        t->Branch("multiclus_pcaPosX", &multiclus_pcaPosX);  
-        t->Branch("multiclus_pcaPosY", &multiclus_pcaPosY);  
-        t->Branch("multiclus_pcaPosZ", &multiclus_pcaPosZ);  
-        t->Branch("multiclus_eigenVal1", &multiclus_eigenVal1);
-        t->Branch("multiclus_eigenVal2", &multiclus_eigenVal2);
-        t->Branch("multiclus_eigenVal3", &multiclus_eigenVal3);
-        t->Branch("multiclus_eigenSig1", &multiclus_eigenSig1);
-        t->Branch("multiclus_eigenSig2", &multiclus_eigenSig2);
-        t->Branch("multiclus_eigenSig3", &multiclus_eigenSig3);
-        t->Branch("multiclus_siguu", &multiclus_siguu);
-        t->Branch("multiclus_sigvv", &multiclus_sigvv);
-        t->Branch("multiclus_sigrad", &multiclus_sigrad);
-        t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
-        t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
-        t->Branch("multiclus_firstLay",&multiclus_firstLay);
-        t->Branch("multiclus_lastLay",&multiclus_lastLay);
-        t->Branch("multiclus_NLay",&multiclus_NLay);
-        
-        
-        ////////////////////
-        // sim clusters
-        //
-        t->Branch("simcluster_eta", &simcluster_eta);
-        t->Branch("simcluster_phi", &simcluster_phi);
-        t->Branch("simcluster_pt", &simcluster_pt);
-        t->Branch("simcluster_energy", &simcluster_energy);
-        t->Branch("simcluster_simEnergy", &simcluster_simEnergy);
-        t->Branch("simcluster_hits", &simcluster_hits);
-        t->Branch("simcluster_fractions", &simcluster_fractions);
-        t->Branch("simcluster_layers", &simcluster_layers);
-        t->Branch("simcluster_wafers", &simcluster_wafers);
-        t->Branch("simcluster_cells", &simcluster_cells);
-        
-        
-        ////////////////////
-        // PF clusters
-        //
-        t->Branch("pfcluster_eta", &pfcluster_eta);
-        t->Branch("pfcluster_phi", &pfcluster_phi);
-        t->Branch("pfcluster_pt", &pfcluster_pt);
-        t->Branch("pfcluster_energy", &pfcluster_energy);
-        
-        
-        ////////////////////
-        // calo particles
-        //
-        t->Branch("calopart_eta", &calopart_eta);
-        t->Branch("calopart_phi", &calopart_phi);
-        t->Branch("calopart_pt", &calopart_pt);
-        t->Branch("calopart_energy", &calopart_energy);
-        t->Branch("calopart_simEnergy", &calopart_simEnergy);
-        t->Branch("calopart_simClusterIndex", &calopart_simClusterIndex);
-  
+	usesResource(TFileService::kSharedResource);
+	edm::Service<TFileService> fs;
+	fs->make<TH1F>("total", "total", 100, 0, 5.);
+	
+	t = fs->make<TTree>("hgc","hgc");
 
-        ////////////////////
-        // high purity trackstatep
-        //
-        t->Branch("track_eta", &track_eta);
-        t->Branch("track_phi", &track_phi);
-        t->Branch("track_pt", &track_pt);
-        t->Branch("track_energy", &track_energy);
-        t->Branch("track_charge", &track_charge);
-        t->Branch("track_posx", &track_posx);
-        t->Branch("track_posy", &track_posy);
-        t->Branch("track_posz", &track_posz);
-        
+	// event info
+	t->Branch("event", &ev_event);
+	t->Branch("lumi", &ev_lumi);
+	t->Branch("run", &ev_run);
+	t->Branch("vtx_x", &vtx_x);
+	t->Branch("vtx_y", &vtx_y);
+	t->Branch("vtx_z", &vtx_z);
+	
+	t->Branch("genpart_eta", &genpart_eta);
+	t->Branch("genpart_phi", &genpart_phi);
+	t->Branch("genpart_pt", &genpart_pt);
+	t->Branch("genpart_energy", &genpart_energy);
+	t->Branch("genpart_dvx", &genpart_dvx);
+	t->Branch("genpart_dvy", &genpart_dvy);
+	t->Branch("genpart_dvz", &genpart_dvz);
+	t->Branch("genpart_fbrem", &genpart_fbrem);
+	t->Branch("genpart_pid", &genpart_pid);
+	t->Branch("genpart_gen", &genpart_gen);
+	t->Branch("genpart_reachedEE", &genpart_reachedEE);
+	t->Branch("genpart_fromBeamPipe", &genpart_fromBeamPipe);
+	t->Branch("genpart_posx", &genpart_posx);
+	t->Branch("genpart_posy", &genpart_posy);
+	t->Branch("genpart_posz", &genpart_posz);
+	
+	////////////////////
+	// RecHits
+	// associated to layer clusters
+	t->Branch("rechit_eta", &rechit_eta);
+	t->Branch("rechit_phi", &rechit_phi);
+	t->Branch("rechit_pt", &rechit_pt);
+	t->Branch("rechit_energy", &rechit_energy);
+	t->Branch("rechit_x", &rechit_x);
+	t->Branch("rechit_y", &rechit_y);
+	t->Branch("rechit_z", &rechit_z);
+	t->Branch("rechit_time", &rechit_time);
+	t->Branch("rechit_thickness", &rechit_thickness);
+	t->Branch("rechit_layer", &rechit_layer);
+	t->Branch("rechit_wafer", &rechit_wafer);
+	t->Branch("rechit_cell", &rechit_cell);
+	t->Branch("rechit_detid", &rechit_detid);
+	t->Branch("rechit_isHalf", &rechit_isHalf);
+	t->Branch("rechit_flags", &rechit_flags);
+	t->Branch("rechit_cluster2d", &rechit_cluster2d);
+
+	////////////////////
+	// layer clusters
+	//
+	t->Branch("cluster2d_eta", &cluster2d_eta);
+	t->Branch("cluster2d_phi", &cluster2d_phi);
+	t->Branch("cluster2d_pt", &cluster2d_pt);
+	t->Branch("cluster2d_energy", &cluster2d_energy);
+	t->Branch("cluster2d_x", &cluster2d_x);
+	t->Branch("cluster2d_y", &cluster2d_y);
+	t->Branch("cluster2d_z", &cluster2d_z);
+	t->Branch("cluster2d_layer", &cluster2d_layer);
+	t->Branch("cluster2d_nhitCore", &cluster2d_nhitCore);
+	t->Branch("cluster2d_nhitAll", &cluster2d_nhitAll);
+	t->Branch("cluster2d_multicluster", &cluster2d_multicluster);
+	t->Branch("cluster2d_rechits", &cluster2d_rechits);
+	t->Branch("cluster2d_rechitSeed", &cluster2d_rechitSeed);
+
+	////////////////////
+	// multi clusters
+	//
+	t->Branch("multiclus_eta", &multiclus_eta);
+	t->Branch("multiclus_phi", &multiclus_phi);
+	t->Branch("multiclus_pt", &multiclus_pt);
+	t->Branch("multiclus_energy", &multiclus_energy);
+	t->Branch("multiclus_z", &multiclus_z);
+	t->Branch("multiclus_slopeX", &multiclus_slopeX);
+	t->Branch("multiclus_slopeY", &multiclus_slopeY);
+	t->Branch("multiclus_cluster2d", &multiclus_cluster2d);
+	t->Branch("multiclus_cl2dSeed", &multiclus_cl2dSeed);
+	t->Branch("multiclus_pcaAxisX", &multiclus_pcaAxisX); 
+	t->Branch("multiclus_pcaAxisY", &multiclus_pcaAxisY); 
+	t->Branch("multiclus_pcaAxisZ", &multiclus_pcaAxisZ);
+	t->Branch("multiclus_pcaPosX", &multiclus_pcaPosX);  
+	t->Branch("multiclus_pcaPosY", &multiclus_pcaPosY);  
+	t->Branch("multiclus_pcaPosZ", &multiclus_pcaPosZ);  
+	t->Branch("multiclus_eigenVal1", &multiclus_eigenVal1);
+	t->Branch("multiclus_eigenVal2", &multiclus_eigenVal2);
+	t->Branch("multiclus_eigenVal3", &multiclus_eigenVal3);
+	t->Branch("multiclus_eigenSig1", &multiclus_eigenSig1);
+	t->Branch("multiclus_eigenSig2", &multiclus_eigenSig2);
+	t->Branch("multiclus_eigenSig3", &multiclus_eigenSig3);
+	t->Branch("multiclus_siguu", &multiclus_siguu);
+	t->Branch("multiclus_sigvv", &multiclus_sigvv);
+	t->Branch("multiclus_sigrad", &multiclus_sigrad);
+	t->Branch("multiclus_radsiguu", &multiclus_radsiguu);
+	t->Branch("multiclus_radsigvv", &multiclus_radsigvv);
+	t->Branch("multiclus_firstLay",&multiclus_firstLay);
+	t->Branch("multiclus_lastLay",&multiclus_lastLay);
+	t->Branch("multiclus_NLay",&multiclus_NLay);
+	
+	
+	////////////////////
+	// sim clusters
+	//
+	t->Branch("simcluster_eta", &simcluster_eta);
+	t->Branch("simcluster_phi", &simcluster_phi);
+	t->Branch("simcluster_pt", &simcluster_pt);
+	t->Branch("simcluster_energy", &simcluster_energy);
+	t->Branch("simcluster_simEnergy", &simcluster_simEnergy);
+	t->Branch("simcluster_hits", &simcluster_hits);
+	t->Branch("simcluster_fractions", &simcluster_fractions);
+	t->Branch("simcluster_layers", &simcluster_layers);
+	t->Branch("simcluster_wafers", &simcluster_wafers);
+	t->Branch("simcluster_cells", &simcluster_cells);
+	
+	
+	////////////////////
+	// PF clusters
+	//
+	t->Branch("pfcluster_eta", &pfcluster_eta);
+	t->Branch("pfcluster_phi", &pfcluster_phi);
+	t->Branch("pfcluster_pt", &pfcluster_pt);
+	t->Branch("pfcluster_energy", &pfcluster_energy);
+	
+	
+	////////////////////
+	// calo particles
+	//
+	t->Branch("calopart_eta", &calopart_eta);
+	t->Branch("calopart_phi", &calopart_phi);
+	t->Branch("calopart_pt", &calopart_pt);
+	t->Branch("calopart_energy", &calopart_energy);
+	t->Branch("calopart_simEnergy", &calopart_simEnergy);
+	t->Branch("calopart_simClusterIndex", &calopart_simClusterIndex);
+
+
+	////////////////////
+	// high purity trackstatep
+	//
+	t->Branch("track_eta", &track_eta);
+	t->Branch("track_phi", &track_phi);
+	t->Branch("track_pt", &track_pt);
+	t->Branch("track_energy", &track_energy);
+	t->Branch("track_charge", &track_charge);
+	t->Branch("track_posx", &track_posx);
+	t->Branch("track_posy", &track_posy);
+	t->Branch("track_posz", &track_posz);
+		
 }
 HGCalAnalysis::~HGCalAnalysis()
 {
   
-        // do anything here that needs to be done at desctruction time
+		// do anything here that needs to be done at desctruction time
 	// (e.g. close files, deallocate resources etc.)
 
 }
@@ -507,7 +507,7 @@ HGCalAnalysis::~HGCalAnalysis()
 //
 void HGCalAnalysis::clearVariables() {
 
-        ev_run = 0;
+	ev_run = 0;
 	ev_lumi = 0;
 	ev_event = 0;
 	vtx_x = 0;
@@ -582,7 +582,7 @@ void HGCalAnalysis::clearVariables() {
 	multiclus_slopeY.clear();
 	multiclus_cluster2d.clear();
 	multiclus_cl2dSeed.clear();
-        multiclus_pcaAxisX.clear(); 	
+	multiclus_pcaAxisX.clear(); 	
 	multiclus_pcaAxisY.clear(); 
 	multiclus_pcaAxisZ.clear(); 
 	multiclus_pcaPosX.clear();  
@@ -768,7 +768,7 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 			}
 		}
 	} else
-	  {
+	{	
 		unsigned int npart = mySimEvent->nTracks();
 		for (unsigned int i=0; i<npart; ++i) {
 			std::vector<float> xp,yp,zp;
@@ -794,29 +794,29 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 						double dpt=0;
 						
 						for(int i=0; i<myTrack.nDaughters(); ++i)
-						  dpt+=myTrack.daughter(i).momentum().pt();
+						  	dpt+=myTrack.daughter(i).momentum().pt();
 						if(abs(myTrack.type())==11)
-						  fbrem = dpt/myTrack.momentum().pt();
+						  	fbrem = dpt/myTrack.momentum().pt();
 					}
 					if (result==1) reachedEE=1;
 				}
 				else // in that case we propagate only to the first layers
-				  nlayers=1;
+				  	nlayers=1;
 				
 				for(unsigned il=0; il<nlayers; ++il) {
-				  myPropag.setPropagationConditions(140,layerPositions[il],false);
-				  if(il>0) // set PID 22 for a straight-line extrapolation after the 1st layer
-				    myPropag.setID(22);
-				  myPropag.propagate();
-				  RawParticle propParticle=myPropag.propagated();
-				  xp.push_back(propParticle.vertex().x());
-				  yp.push_back(propParticle.vertex().y());
-				  zp.push_back(propParticle.vertex().z());
+					myPropag.setPropagationConditions(140,layerPositions[il],false);
+					if(il>0) // set PID 22 for a straight-line extrapolation after the 1st layer
+						myPropag.setID(22);
+					myPropag.propagate();
+					RawParticle propParticle=myPropag.propagated();
+					xp.push_back(propParticle.vertex().x());
+					yp.push_back(propParticle.vertex().y());
+					zp.push_back(propParticle.vertex().z());
 				}
 			}
 			else
-			  {
-			    vtx = myTrack.endVertex().position();
+		  	{	
+				vtx = myTrack.endVertex().position();
 			}
 			
 			// fill branches
@@ -902,7 +902,7 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		std::vector<unsigned int> cl2dIndices;
 
 		for(reco::HGCalMultiCluster::component_iterator it = multiClusters[i].begin();
-		    it!=multiClusters[i].end(); it++) {
+			it!=multiClusters[i].end(); it++) {
 
 			if((*it)->energy() > (*(it+cl2dSeed))->energy()) cl2dSeed = it - multiClusters[i].begin();
 			cl2dIndices.push_back(cluster_index);
@@ -925,26 +925,26 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		multiclus_lastLay.push_back(*layers.rbegin());
 		multiclus_NLay.push_back(layers.size());
 		if(multiClusters[i].size()<3)
-		  {
-		    multiclus_pcaAxisX.push_back(-2.);
-		    multiclus_pcaAxisY.push_back(-2.);
-		    multiclus_pcaAxisZ.push_back(-2.);
-		    multiclus_pcaPosX.push_back(-2.);
-		    multiclus_pcaPosY.push_back(-2.);
-		    multiclus_pcaPosZ.push_back(-2.);
-		    multiclus_eigenVal1.push_back(-2.);
-		    multiclus_eigenVal2.push_back(-2.);
-		    multiclus_eigenVal3.push_back(-2.);
-		    multiclus_eigenSig1.push_back(-2.);
-		    multiclus_eigenSig2.push_back(-2.);
-		    multiclus_eigenSig3.push_back(-2.);
-		    multiclus_siguu.push_back(-2.);
-		    multiclus_sigvv.push_back(-2.);
-		    std::vector<float> dummy;
-		    multiclus_sigrad.push_back(dummy);
-		    multiclus_radsiguu.push_back(dummy);
-		    multiclus_radsigvv.push_back(dummy);
-		    continue;
+		  	{
+			multiclus_pcaAxisX.push_back(-2.);
+			multiclus_pcaAxisY.push_back(-2.);
+			multiclus_pcaAxisZ.push_back(-2.);
+			multiclus_pcaPosX.push_back(-2.);
+			multiclus_pcaPosY.push_back(-2.);
+			multiclus_pcaPosZ.push_back(-2.);
+			multiclus_eigenVal1.push_back(-2.);
+			multiclus_eigenVal2.push_back(-2.);
+			multiclus_eigenVal3.push_back(-2.);
+			multiclus_eigenSig1.push_back(-2.);
+			multiclus_eigenSig2.push_back(-2.);
+			multiclus_eigenSig3.push_back(-2.);
+			multiclus_siguu.push_back(-2.);
+			multiclus_sigvv.push_back(-2.);
+			std::vector<float> dummy;
+			multiclus_sigrad.push_back(dummy);
+			multiclus_radsiguu.push_back(dummy);
+			multiclus_radsigvv.push_back(dummy);
+			continue;
 		  }
 		pca_->MakePrincipals();
 		const TVectorD means = *(pca_->GetMeanValues());
@@ -954,24 +954,25 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 		math::XYZPoint barycenter(means[0],means[1],means[2]);
 		math::XYZVector axis(eigens(0,0),eigens(1,0),eigens(2,0));
 		if( axis.z()*barycenter.z() < 0.0 ) {
-		  axis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
+		  	axis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
 		}
 		float sigu,sigv;
 		std::vector<float> radsiguu;
 		std::vector<float> radsigvv;
 		std::vector<float> sigrad;
 
-                //		for(float radius=1.;  radius<=10.; radius+=1.) {
-                float radius=5.;
-                
-                computeWidth(multiClusters[i],barycenter,axis,sigu,sigv,radius);
-                sigrad.push_back(radius);
-                radsiguu.push_back(sigu);
-                radsigvv.push_back(sigv);
-                if (radius>4.9 && radius < 5.1) {
-                  multiclus_siguu.push_back(sigu);
-                  multiclus_sigvv.push_back(sigv);
-                  //                }
+				//		for(float radius=1.;  radius<=10.; radius+=1.) {
+		float radius=5.;
+		
+		computeWidth(multiClusters[i],barycenter,axis,sigu,sigv,radius);
+		sigrad.push_back(radius);
+		radsiguu.push_back(sigu);
+		radsigvv.push_back(sigv);
+		// not elegant, but keep it because of the commented loop above
+		if (radius>4.9 && radius < 5.1) {
+		 	multiclus_siguu.push_back(sigu);
+			multiclus_sigvv.push_back(sigv);
+				  //                }
 		}
 
 		multiclus_pcaAxisX.push_back(axis.x());
@@ -1086,30 +1087,30 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	// loop over pfClusters
 	for (std::vector<reco::PFCluster>::const_iterator it_pfClus = pfClusters.begin(); it_pfClus != pfClusters.end(); ++it_pfClus) {
 	  
-	  pfcluster_eta.push_back(it_pfClus->eta());
-	  pfcluster_phi.push_back(it_pfClus->phi());
-	  pfcluster_pt.push_back(it_pfClus->pt());
-	  pfcluster_energy.push_back(it_pfClus->energy());
+	  	pfcluster_eta.push_back(it_pfClus->eta());
+	  	pfcluster_phi.push_back(it_pfClus->phi());
+	  	pfcluster_pt.push_back(it_pfClus->pt());
+	  	pfcluster_energy.push_back(it_pfClus->energy());
 	  
 	} // end loop over pfClusters
 	
 	// loop over caloParticles
 	if (readCaloParticles) {
-	  for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles->begin(); it_caloPart != caloParticles->end(); ++it_caloPart) {
-	    const SimClusterRefVector simClusterRefVector = it_caloPart->simClusters();
-	    std::vector<uint32_t> simClusterIndex;
-	    for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
-	      simClusterIndex.push_back((*it_sc).key());
-	    }
-	    
-	    calopart_eta.push_back(it_caloPart->eta());
-	    calopart_phi.push_back(it_caloPart->phi());
-	    calopart_pt.push_back(it_caloPart->pt());
-	    calopart_energy.push_back(it_caloPart->energy());
-	    calopart_simEnergy.push_back(it_caloPart->simEnergy());
-	    calopart_simClusterIndex.push_back(simClusterIndex);
-	    
-	  } // end loop over caloParticles
+	  	for (std::vector<CaloParticle>::const_iterator it_caloPart = caloParticles->begin(); it_caloPart != caloParticles->end(); ++it_caloPart) {
+			const SimClusterRefVector simClusterRefVector = it_caloPart->simClusters();
+			std::vector<uint32_t> simClusterIndex;
+			for (CaloParticle::sc_iterator it_sc = simClusterRefVector.begin(); it_sc != simClusterRefVector.end(); ++it_sc) {
+		  		simClusterIndex.push_back((*it_sc).key());
+			}
+		
+			calopart_eta.push_back(it_caloPart->eta());
+			calopart_phi.push_back(it_caloPart->phi());
+			calopart_pt.push_back(it_caloPart->pt());
+			calopart_energy.push_back(it_caloPart->energy());
+			calopart_simEnergy.push_back(it_caloPart->simEnergy());
+			calopart_simClusterIndex.push_back(simClusterIndex);
+		
+	  	} // end loop over caloParticles
 	}
 	
 	// loop over tracks
@@ -1123,73 +1124,72 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	
 	for (std::vector<reco::Track>::const_iterator it_track = tracks.begin(); it_track != tracks.end(); ++it_track) {
 	  
-	  if (!it_track->quality(reco::Track::highPurity)) continue;
+	  	if (!it_track->quality(reco::Track::highPurity)) continue;
 	  
-	  double energy = it_track->pt() * cosh(it_track->eta());
+	 	double energy = it_track->pt() * cosh(it_track->eta());
 	  
-	  //save info about reconstructed tracks propoagation to hgcal layers (ony for pt>propagationPtThreshold tracks)
-	  std::vector<float> xp,yp,zp;
+	  	//save info about reconstructed tracks propoagation to hgcal layers (ony for pt>propagationPtThreshold tracks)
+	  	std::vector<float> xp,yp,zp;
 	  
-	  if (it_track->pt()>= propagationPtThreshold) {
-	    
-	      // Define error matrix
-	      ROOT::Math::SMatrixIdentity id;
-	    AlgebraicSymMatrix55 C(id);
-	    C *= 0.01;
-	    CurvilinearTrajectoryError err(C);
-	    typedef TrajectoryStateOnSurface TSOS;
-	    
-	    GlobalPoint startingPosition(it_track->vx(),it_track->vy(),it_track->vz());
-	    GlobalVector startingMomentum(it_track->px(),it_track->py(),it_track->pz());
-	    
-	    Plane::PlanePointer startingPlane = Plane::build( Plane::PositionType (it_track->vx(),it_track->vy(),it_track->vz()), Plane::RotationType () );
-	    
-	    TSOS startingStateP(GlobalTrajectoryParameters(startingPosition,startingMomentum, it_track->charge(), aField), err, *startingPlane);
-	    
-	    for(unsigned il=0; il<layerPositions.size(); ++il) {
-	      float xp_curr=0;
-	      float yp_curr=0;
-	      float zp_curr=0;
-	      
-	      for (int zside = -1; zside <=1; zside+=2)
-		{
-		  // clearly try both sides
-		  Plane::PlanePointer endPlane = Plane::build( Plane::PositionType (0,0,zside*layerPositions[il]), Plane::RotationType());
-		  try{
-		    /*
-		      std::cout << "Trying from " <<
-		      " layer " << il <<
-		      " starting point " << startingStateP.globalPosition() <<
-		      std::endl;
-		    */
-		    TSOS trackStateP = RKProp.propagate( startingStateP, *endPlane);
-		    if (trackStateP.isValid()) {
-		      xp_curr=trackStateP.globalPosition().x();
-		      yp_curr=trackStateP.globalPosition().y();
-		      zp_curr=trackStateP.globalPosition().z();
-		      
-		      // std::cout << "Succesfully finished Positive track propagation  -------------- with RK: " << trackStateP.globalPosition() << std::endl;
-		    }
-		  }
-		  catch (...) {
-		    std::cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << std::endl;
-		  }
-		}
-	      xp.push_back(xp_curr);
-	      yp.push_back(yp_curr);
-	      zp.push_back(zp_curr);
-	    } // closes loop on layers
-	  } // closes conditions pt>3
+	  	if (it_track->pt()>= propagationPtThreshold) {
+		
+			 // Define error matrix
+			ROOT::Math::SMatrixIdentity id;
+			AlgebraicSymMatrix55 C(id);
+			C *= 0.01;
+			CurvilinearTrajectoryError err(C);
+			typedef TrajectoryStateOnSurface TSOS;
+			
+			GlobalPoint startingPosition(it_track->vx(),it_track->vy(),it_track->vz());
+			GlobalVector startingMomentum(it_track->px(),it_track->py(),it_track->pz());
+			
+			Plane::PlanePointer startingPlane = Plane::build( Plane::PositionType (it_track->vx(),it_track->vy(),it_track->vz()), Plane::RotationType () );
+			
+			TSOS startingStateP(GlobalTrajectoryParameters(startingPosition,startingMomentum, it_track->charge(), aField), err, *startingPlane);
+			
+			for(unsigned il=0; il<layerPositions.size(); ++il) {
+			  	float xp_curr=0;
+			  	float yp_curr=0;
+			  	float zp_curr=0;
+			  
+			  	for (int zside = -1; zside <=1; zside+=2) {
+				// clearly try both sides	
+			  		Plane::PlanePointer endPlane = Plane::build( Plane::PositionType (0,0,zside*layerPositions[il]), Plane::RotationType());
+			  		try{
+					/*
+				  	std::cout << "Trying from " <<
+				  	" layer " << il <<
+				  	" starting point " << startingStateP.globalPosition() <<
+				  	std::endl;
+					*/
+						TSOS trackStateP = RKProp.propagate( startingStateP, *endPlane);
+						if (trackStateP.isValid()) {
+				  			xp_curr=trackStateP.globalPosition().x();
+				  			yp_curr=trackStateP.globalPosition().y();
+				  			zp_curr=trackStateP.globalPosition().z();
+				  
+				  			// std::cout << "Succesfully finished Positive track propagation  -------------- with RK: " << trackStateP.globalPosition() << std::endl;
+						}
+		     		}		
+			  		catch (...) {
+						std::cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << std::endl;
+			  		}
+				}	
+				xp.push_back(xp_curr);
+				yp.push_back(yp_curr);
+				zp.push_back(zp_curr);
+			} // closes loop on layers
+		} // closes conditions pt>3
 	  
-	  // save info in tree
-	  track_pt.push_back(it_track->pt());
-	  track_pt.push_back(it_track->eta());
-	  track_pt.push_back(it_track->phi());
-	  track_pt.push_back(energy);
-	  track_pt.push_back(it_track->charge());
-	  track_posx.push_back(xp);
-	  track_posy.push_back(yp);
-	  track_posz.push_back(zp);
+		// save info in tree
+		track_pt.push_back(it_track->pt());
+		track_pt.push_back(it_track->eta());
+		track_pt.push_back(it_track->phi());
+		track_pt.push_back(energy);
+		track_pt.push_back(it_track->charge());
+		track_posx.push_back(xp);
+		track_posy.push_back(yp);
+		track_posz.push_back(zp);
 	  
 	} // end loop over tracks
 	
@@ -1206,16 +1206,16 @@ HGCalAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 void HGCalAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
   
-            edm::ESHandle < HepPDT::ParticleDataTable > pdt;
-            es.getData(pdt);
-            mySimEvent->initializePdt(&(*pdt));
+		edm::ESHandle < HepPDT::ParticleDataTable > pdt;
+		es.getData(pdt);
+		mySimEvent->initializePdt(&(*pdt));
   
-            retrieveLayerPositions(es,52);
+		retrieveLayerPositions(es,52);
   
-            edm::ESHandle<MagneticField> magfield;
-            es.get<IdealMagneticFieldRecord>().get(magfield);
+		edm::ESHandle<MagneticField> magfield;
+		es.get<IdealMagneticFieldRecord>().get(magfield);
   
-            aField=&(*magfield);
+		aField=&(*magfield);
   
 }
 
@@ -1225,7 +1225,7 @@ void HGCalAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {
 void
 HGCalAnalysis::beginJob()
 {
-            ;
+			;
 }
 
  // ------------ method called once each job just after ending the event loop  ------------
@@ -1239,241 +1239,241 @@ HGCalAnalysis::endJob()
 
 void HGCalAnalysis::retrieveLayerPositions(const edm::EventSetup& es, unsigned layers)
 {
-  recHitTools.getEventSetup(es);
+  	recHitTools.getEventSetup(es);
   
-  DetId id;
-  for(unsigned ilayer=1; ilayer<=layers; ++ilayer) {
-    if (ilayer<=28) id=HGCalDetId(ForwardSubdetector::HGCEE,1,ilayer,1,50,1);
-    if (ilayer>28 && ilayer<=40) id=HGCalDetId(ForwardSubdetector::HGCHEF,1,ilayer-28,1,50,1);
-    if (ilayer>40) id=HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, ilayer-40);
-    const GlobalPoint pos = recHitTools.getPosition(id);
-    //		 std::cout << "GEOM " ;
-    //		 std::cout << " layer " << ilayer << " " << pos.z() << std::endl;
-    
-    layerPositions.push_back(pos.z());
+  	DetId id;
+  	for(unsigned ilayer=1; ilayer<=layers; ++ilayer) {
+		if (ilayer<=28) id=HGCalDetId(ForwardSubdetector::HGCEE,1,ilayer,1,50,1);
+		if (ilayer>28 && ilayer<=40) id=HGCalDetId(ForwardSubdetector::HGCHEF,1,ilayer-28,1,50,1);
+		if (ilayer>40) id=HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, ilayer-40);
+		const GlobalPoint pos = recHitTools.getPosition(id);
+		//  std::cout << "GEOM " ;
+		//	std::cout << " layer " << ilayer << " " << pos.z() << std::endl;
+	
+		layerPositions.push_back(pos.z());
   }
 }
 
 
 int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster>& layerCluster, const bool& fillRecHits, const int& multiClusterIndex) {
   
-            // std::cout << "in fillLayerCluster" << std::endl;
-            const std::vector< std::pair<DetId, float> > &hf = layerCluster->hitsAndFractions();
-            std::vector<unsigned int> rhIndices;
-            int ncoreHit = 0;
-            int layer = 0;
-            int rhSeed = 0;
-            if (!fillRecHits) {
-              rhSeed = -1;
-            }
-            float maxEnergy = -1.;
-            Double_t pcavars[3];
-            unsigned hfsize=hf.size();
-  
-            for(unsigned int j = 0; j < hfsize; j++) {
-              //here we loop over detid/fraction pairs
-              float fraction = hf[j].second;
-              const DetId rh_detid = hf[j].first;
-              layer = recHitTools.getLayerWithOffset(rh_detid);
-              const HGCRecHit *hit = hitmap[rh_detid];
-              ncoreHit += int(fraction);
-    
-              double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
-              double mip=dEdXWeights[layer]*0.001; // convert in GeV
-              if (thickness > 99. && thickness < 101) 
-                mip *= invThicknessCorrection[0];
-              else if (thickness > 199 && thickness <201)
-                mip *= invThicknessCorrection[1];
-              else if (thickness > 299 && thickness <301)
-                mip *= invThicknessCorrection[2];
-              //		std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;
-    
-              if(multiClusterIndex>=0 and fraction>0 && mip > 0) {
-                pcavars[0] = recHitTools.getPosition(rh_detid).x();
-                pcavars[1] = recHitTools.getPosition(rh_detid).y();
-                pcavars[2] = recHitTools.getPosition(rh_detid).z();
-      //		  std::cout << pcavars[0] << " " << pcavars[1] << " " << pcavars[2] << std::endl;
-      //		  std::cout << " Multiplicity " << int(hit->energy()/mip) <<std::endl;
-                if(pcavars[2]!=0)
-                  for (int i=0; i<int(hit->energy()/mip); ++i)
-                    pca_->AddRow(pcavars);
-              }
-              
-    
-              if (fillRecHits) {
-                if(storedRecHits.find(rh_detid)==storedRecHits.end() ) {
-                  // std::cout << "in fillLayerCluster: RecHit not yet filled" << std::endl;
-                  // std::cout << "in fillLayerCluster: hit energy: " << hit->energy() << std::endl;
-                  // std::cout << "in fillLayerCluster: first hit energy: " << maxEnergy << std::endl;
-                  if(hit->energy() > maxEnergy) {
-                    rhSeed = rechit_index;
-                    maxEnergy = hit->energy();
-                  }
-                  rhIndices.push_back(rechit_index);
-                  fillRecHit(rh_detid, fraction, layer, cluster_index);
-                }
-                else {
-                  // need to see what to do about existing rechits in case of sharing
-                  std::cout << "RecHit already filled for different layer cluster: " << int(rh_detid) << std::endl;
-                }
-              }
-            }
-  
-            double pt = layerCluster->energy() / cosh(layerCluster->eta());
-  
-            cluster2d_eta.push_back(layerCluster->eta());
-            cluster2d_phi.push_back(layerCluster->phi());
-            cluster2d_pt.push_back(pt);
-            cluster2d_energy.push_back(layerCluster->energy());
-            cluster2d_x.push_back(layerCluster->x());
-            cluster2d_y.push_back(layerCluster->y());
-            cluster2d_z.push_back(layerCluster->z());
-            cluster2d_layer.push_back(layer);
-            cluster2d_nhitCore.push_back(ncoreHit);
-            cluster2d_nhitAll.push_back(hf.size());
-            cluster2d_multicluster.push_back(multiClusterIndex);
-            cluster2d_rechitSeed.push_back(rhSeed);
-            cluster2d_rechits.push_back(rhIndices);
-  
-            storedLayerClusters.insert(layerCluster);
-            ++cluster_index;
-            return layer;
+	// std::cout << "in fillLayerCluster" << std::endl;
+	const std::vector< std::pair<DetId, float> > &hf = layerCluster->hitsAndFractions();
+	std::vector<unsigned int> rhIndices;
+	int ncoreHit = 0;
+	int layer = 0;
+	int rhSeed = 0;
+	if (!fillRecHits) {
+	  rhSeed = -1;
+	}
+	float maxEnergy = -1.;
+	Double_t pcavars[3];
+	unsigned hfsize=hf.size();
+
+	for(unsigned int j = 0; j < hfsize; j++) {
+	  	//here we loop over detid/fraction pairs
+	  	float fraction = hf[j].second;
+	  	const DetId rh_detid = hf[j].first;
+	  	layer = recHitTools.getLayerWithOffset(rh_detid);
+	  	const HGCRecHit *hit = hitmap[rh_detid];
+	  	ncoreHit += int(fraction);
+
+	  	double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
+	  	double mip=dEdXWeights[layer]*0.001; // convert in GeV
+	  	if (thickness > 99. && thickness < 101) 
+			mip *= invThicknessCorrection[0];
+	  	else if (thickness > 199 && thickness <201)
+			mip *= invThicknessCorrection[1];
+	  	else if (thickness > 299 && thickness <301)
+			mip *= invThicknessCorrection[2];
+	  //		std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;
+
+	  	if(multiClusterIndex>=0 and fraction>0 && mip > 0) {
+			pcavars[0] = recHitTools.getPosition(rh_detid).x();
+			pcavars[1] = recHitTools.getPosition(rh_detid).y();
+			pcavars[2] = recHitTools.getPosition(rh_detid).z();
+//		  std::cout << pcavars[0] << " " << pcavars[1] << " " << pcavars[2] << std::endl;
+//		  std::cout << " Multiplicity " << int(hit->energy()/mip) <<std::endl;
+		if(pcavars[2]!=0)
+		  	for (int i=0; i<int(hit->energy()/mip); ++i)
+				pca_->AddRow(pcavars);
+	}	
+	  
+
+	 if (fillRecHits) {
+		if(storedRecHits.find(rh_detid)==storedRecHits.end() ) {
+		  // std::cout << "in fillLayerCluster: RecHit not yet filled" << std::endl;
+		  // std::cout << "in fillLayerCluster: hit energy: " << hit->energy() << std::endl;
+		  // std::cout << "in fillLayerCluster: first hit energy: " << maxEnergy << std::endl;
+		  	if(hit->energy() > maxEnergy) {
+				rhSeed = rechit_index;
+				maxEnergy = hit->energy();
+		  	}	
+		  	rhIndices.push_back(rechit_index);
+		  	fillRecHit(rh_detid, fraction, layer, cluster_index);
+		}	
+		else {
+		  // need to see what to do about existing rechits in case of sharing
+		 std::cout << "RecHit already filled for different layer cluster: " << int(rh_detid) << std::endl;
+		}	
+	  }
+	}
+
+	double pt = layerCluster->energy() / cosh(layerCluster->eta());
+
+	cluster2d_eta.push_back(layerCluster->eta());
+	cluster2d_phi.push_back(layerCluster->phi());
+	cluster2d_pt.push_back(pt);
+	cluster2d_energy.push_back(layerCluster->energy());
+	cluster2d_x.push_back(layerCluster->x());
+	cluster2d_y.push_back(layerCluster->y());
+	cluster2d_z.push_back(layerCluster->z());
+	cluster2d_layer.push_back(layer);
+	cluster2d_nhitCore.push_back(ncoreHit);
+	cluster2d_nhitAll.push_back(hf.size());
+	cluster2d_multicluster.push_back(multiClusterIndex);
+	cluster2d_rechitSeed.push_back(rhSeed);
+	cluster2d_rechits.push_back(rhIndices);
+
+	storedLayerClusters.insert(layerCluster);
+	++cluster_index;
+	return layer;
 }
 
 
 void HGCalAnalysis::fillRecHit(const DetId& detid, const float& fraction, const unsigned int& layer, const int& cluster_index) {
   
-            // std::cout << "in fillRecHit" << std::endl;
-        int flags = 0x0;
-        if (fraction>0. && fraction<1.)
-                flags = 0x1;
-        else if(fraction<0.)
-                flags = 0x3;
-        else if(fraction==0.)
-                flags = 0x2;
-        const HGCRecHit *hit = hitmap[detid];
-            
-        const GlobalPoint position = recHitTools.getPosition(detid);
-        const unsigned int wafer = ( DetId::Forward == DetId(detid).det() ? recHitTools.getWafer(detid) : std::numeric_limits<unsigned int>::max() );
-        const unsigned int cell  = ( DetId::Forward == DetId(detid).det() ? recHitTools.getCell(detid) :  std::numeric_limits<unsigned int>::max() );
-        const double cellThickness = ( DetId::Forward == DetId(detid).det() ? recHitTools.getSiThickness(detid) : std::numeric_limits<std::float_t>::max() );
-        const bool isHalfCell = recHitTools.isHalfCell(detid);
-        const double eta = recHitTools.getEta(position, vz);
-        const double phi = recHitTools.getPhi(position);
-        const double pt = recHitTools.getPt(position, hit->energy(), vz);
-        
-  
-        // fill the vectors
-        rechit_eta.push_back(eta);
-        rechit_phi.push_back(phi);
-        rechit_pt.push_back(pt);
-        rechit_energy.push_back(hit->energy());
-        rechit_layer.push_back(layer);
-        rechit_wafer.push_back(wafer);
-        rechit_cell.push_back(cell);
-        rechit_detid.push_back(detid);
-        rechit_x.push_back(position.x());
-        rechit_y.push_back(position.y());
-        rechit_z.push_back(position.z());
-        rechit_time.push_back(hit->time());
-        rechit_thickness.push_back(cellThickness);
-        rechit_isHalf.push_back(isHalfCell);
-        rechit_flags.push_back(flags);
-        rechit_cluster2d.push_back(cluster_index);
-        
-        storedRecHits.insert(detid);
-        ++rechit_index;
-        
+		// std::cout << "in fillRecHit" << std::endl;
+	int flags = 0x0;
+	if (fraction>0. && fraction<1.)
+			flags = 0x1;
+	else if(fraction<0.)
+			flags = 0x3;
+	else if(fraction==0.)
+			flags = 0x2;
+	const HGCRecHit *hit = hitmap[detid];
+		
+	const GlobalPoint position = recHitTools.getPosition(detid);
+	const unsigned int wafer = ( DetId::Forward == DetId(detid).det() ? recHitTools.getWafer(detid) : std::numeric_limits<unsigned int>::max() );
+	const unsigned int cell  = ( DetId::Forward == DetId(detid).det() ? recHitTools.getCell(detid) :  std::numeric_limits<unsigned int>::max() );
+	const double cellThickness = ( DetId::Forward == DetId(detid).det() ? recHitTools.getSiThickness(detid) : std::numeric_limits<std::float_t>::max() );
+	const bool isHalfCell = recHitTools.isHalfCell(detid);
+	const double eta = recHitTools.getEta(position, vz);
+	const double phi = recHitTools.getPhi(position);
+	const double pt = recHitTools.getPt(position, hit->energy(), vz);
+	
+
+	// fill the vectors
+	rechit_eta.push_back(eta);
+	rechit_phi.push_back(phi);
+	rechit_pt.push_back(pt);
+	rechit_energy.push_back(hit->energy());
+	rechit_layer.push_back(layer);
+	rechit_wafer.push_back(wafer);
+	rechit_cell.push_back(cell);
+	rechit_detid.push_back(detid);
+	rechit_x.push_back(position.x());
+	rechit_y.push_back(position.y());
+	rechit_z.push_back(position.z());
+	rechit_time.push_back(hit->time());
+	rechit_thickness.push_back(cellThickness);
+	rechit_isHalf.push_back(isHalfCell);
+	rechit_flags.push_back(flags);
+	rechit_cluster2d.push_back(cluster_index);
+	
+	storedRecHits.insert(detid);
+	++rechit_index;
+		
 }
 
 void HGCalAnalysis::computeWidth(const reco::HGCalMultiCluster& cluster, math::XYZPoint & bar, 
-                                 math::XYZVector& axis, float & sigu, float &sigv, float radius)  {
-        bool recomputePCA=false;
-        sigu = 0.;
-        sigv = 0.;
-        float radius2 = radius*radius;
-  
-        pca_.reset(new TPrincipal(3,"D"));
-        Double_t pcavars[3];
+								 math::XYZVector& axis, float & sigu, float &sigv, float radius)  {
+		bool recomputePCA=false;
+		sigu = 0.;
+		sigv = 0.;
+		float radius2 = radius*radius;
 
-        //  std::cout << " Barycenter " << bar << " " << axis << std::endl;
-        // First build the rotation matrix
-        math::XYZVector mainAxis(axis);
-        mainAxis.unit();
-        math::XYZVector phiAxis(bar.x(),bar.y(),0);
-        math::XYZVector udir(mainAxis.Cross(phiAxis));
-        udir.unit();
-        Transform3D trans(Point(bar),Point(bar+mainAxis),Point(bar+udir),
-                          Point(0,0,0), Point(0.,0.,1.), Point(1.,0.,0.));
+		pca_.reset(new TPrincipal(3,"D"));
+		Double_t pcavars[3];
 
-        //  unsigned nhit=0;
-        float etot=0;
-        for(reco::HGCalMultiCluster::component_iterator it = cluster.begin();
-            it!=cluster.end(); it++) {
-            const std::vector< std::pair<DetId, float> > &hf = (*it)->hitsAndFractions();
-            unsigned hfsize=hf.size();
-            if(hfsize==0) continue;
-            unsigned int layer = recHitTools.getLayerWithOffset(hf[0].first);
-            if(layer>28) continue;
+		//  std::cout << " Barycenter " << bar << " " << axis << std::endl;
+		// First build the rotation matrix
+		math::XYZVector mainAxis(axis);
+		mainAxis.unit();
+		math::XYZVector phiAxis(bar.x(),bar.y(),0);
+		math::XYZVector udir(mainAxis.Cross(phiAxis));
+		udir.unit();
+		Transform3D trans(Point(bar),Point(bar+mainAxis),Point(bar+udir),
+						  Point(0,0,0), Point(0.,0.,1.), Point(1.,0.,0.));
+
+		//  unsigned nhit=0;
+		float etot=0;
+		for(reco::HGCalMultiCluster::component_iterator it = cluster.begin();
+			it!=cluster.end(); it++) {
+			const std::vector< std::pair<DetId, float> > &hf = (*it)->hitsAndFractions();
+			unsigned hfsize=hf.size();
+			if(hfsize==0) continue;
+			unsigned int layer = recHitTools.getLayerWithOffset(hf[0].first);
+			if(layer>28) continue;
 
 
-            for(unsigned int j = 0; j < hfsize; j++) {
-                const DetId rh_detid = hf[j].first;
-                const HGCRecHit *hit = hitmap[rh_detid];
-                float fraction = hf[j].second;
-                if(fraction>0)
-                  {
-                    math::XYZPoint local = trans(Point(recHitTools.getPosition(rh_detid)));
-          
-                    if(local.Perp2() > 25) continue;
-          
-                    if(local.Perp2() < radius2 ) {
-                      sigu += local.x()*local.x()*hit->energy();
-                      sigv += local.y()*local.y()*hit->energy();
-                      etot += hit->energy();
-                      //	    ++nhit;
-                    }
-                    if (!recomputePCA) continue;
-                    double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
-                    double mip=dEdXWeights[layer]*0.001; // convert in GeV
-                    if (thickness > 99. && thickness < 101) 
-                        mip *= invThicknessCorrection[0];
-                    else if (thickness > 199 && thickness <201)
-                        mip *= invThicknessCorrection[1];
-                    else if (thickness > 299 && thickness <301)
-                        mip *= invThicknessCorrection[2];
+			for(unsigned int j = 0; j < hfsize; j++) {
+				const DetId rh_detid = hf[j].first;
+				const HGCRecHit *hit = hitmap[rh_detid];
+				float fraction = hf[j].second;
+				if(fraction>0)
+				  {
+					math::XYZPoint local = trans(Point(recHitTools.getPosition(rh_detid)));
+		  
+					if(local.Perp2() > 25) continue;
+		  
+					if(local.Perp2() < radius2 ) {
+					  sigu += local.x()*local.x()*hit->energy();
+					  sigv += local.y()*local.y()*hit->energy();
+					  etot += hit->energy();
+					  //	    ++nhit;
+					}
+					if (!recomputePCA) continue;
+					double thickness = (DetId::Forward == DetId(rh_detid).det()) ? recHitTools.getSiThickness(rh_detid) : -1 ;
+					double mip=dEdXWeights[layer]*0.001; // convert in GeV
+					if (thickness > 99. && thickness < 101) 
+						mip *= invThicknessCorrection[0];
+					else if (thickness > 199 && thickness <201)
+						mip *= invThicknessCorrection[1];
+					else if (thickness > 299 && thickness <301)
+						mip *= invThicknessCorrection[2];
 
-                    // std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;	    
+					// std::cout << " layer " << layer << " thickness " << thickness << " mip " << mip << std::endl;	    
 	  
-                    pcavars[0] = recHitTools.getPosition(rh_detid).x();
-                    pcavars[1] = recHitTools.getPosition(rh_detid).y();
-                    pcavars[2] = recHitTools.getPosition(rh_detid).z();
-                    if(pcavars[2]!=0){
-                        for (int i=0; i<int(hit->energy()/mip); ++i)
-                            pca_->AddRow(pcavars);
-                    }
-                  }
-            }    
-        }
-        if(etot > 0.) {
-            sigu=sigu/etot;
-            sigv=sigv/etot;
-        }
-        sigu=std::sqrt(sigu);
-        sigv=std::sqrt(sigv);
-  
-        if (recomputePCA) {
-            pca_->MakePrincipals();
-    
-            const TMatrixD& eigens = *(pca_->GetEigenVectors());
-            math::XYZVector newaxis(eigens(0,0),eigens(1,0),eigens(2,0));
-            if( newaxis.z()*bar.z() < 0.0 ) {
-              newaxis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
-            }
-            axis = newaxis;
-            const TVectorD means = *(pca_->GetMeanValues());
-            bar = math::XYZPoint(means[0],means[1],means[2]);
-        }
+					pcavars[0] = recHitTools.getPosition(rh_detid).x();
+					pcavars[1] = recHitTools.getPosition(rh_detid).y();
+					pcavars[2] = recHitTools.getPosition(rh_detid).z();
+					if(pcavars[2]!=0){
+						for (int i=0; i<int(hit->energy()/mip); ++i)
+							pca_->AddRow(pcavars);
+					}
+				  }
+			}    
+		}
+		if(etot > 0.) {
+			sigu=sigu/etot;
+			sigv=sigv/etot;
+		}
+		sigu=std::sqrt(sigu);
+		sigv=std::sqrt(sigv);
+
+		if (recomputePCA) {
+			pca_->MakePrincipals();
+
+			const TMatrixD& eigens = *(pca_->GetEigenVectors());
+			math::XYZVector newaxis(eigens(0,0),eigens(1,0),eigens(2,0));
+			if( newaxis.z()*bar.z() < 0.0 ) {
+			  newaxis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
+			}
+			axis = newaxis;
+			const TVectorD means = *(pca_->GetMeanValues());
+			bar = math::XYZPoint(means[0],means[1],means[2]);
+	}
 }
 
 
@@ -1484,9 +1484,9 @@ void
 HGCalAnalysis::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 	//The following says we do not know what parameters are allowed so do no validation
 	// Please change this to state exactly what you do use, even if it is no parameters
-        edm::ParameterSetDescription desc;
-        desc.setUnknown();
-        descriptions.addDefault(desc);
+	edm::ParameterSetDescription desc;
+	desc.setUnknown();
+	descriptions.addDefault(desc);
 }
 
 /*

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -132,7 +132,7 @@ std::vector<float> genpart_dvz;
 std::vector<float> genpart_fbrem;
 std::vector<int> genpart_pid;
 std::vector<int> genpart_gen;
-std::vector<bool> genpart_reachedEE;
+std::vector<int> genpart_reachedEE;
 std::vector<bool> genpart_fromBeamPipe;
 std::vector<std::vector<float> > genpart_posx;
 std::vector<std::vector<float> > genpart_posy;

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -35,7 +35,7 @@ process.source = cms.Source("PoolSource",
 
 process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              detector = cms.string("all"),
-                             rawRecHits = cms.bool(True),
+                             rawRecHits = cms.bool(False),
                              readOfficialReco = cms.bool(True),
                              readCaloParticles = cms.bool(False),
                              dEdXWeights = dEdX,
@@ -47,7 +47,7 @@ process.ana.TestParticleFilter.protonEMin = cms.double(100000)
 process.ana.TestParticleFilter.etaMax = cms.double(3.1)
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("hgcalNtuple-pca.root")
+                                   fileName = cms.string("hgcalNtuple-pca-clusteringFix-test.root")
 
                                    )
 

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -4,14 +4,14 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process("Demo")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-#process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D13Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('RecoLocalCalo.HGCalRecProducers.HGCalLocalRecoSequence_cff')
-
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 from FastSimulation.Event.ParticleFilter_cfi import *
 from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights as dEdX
 
@@ -20,15 +20,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        #        '/store/relval/CMSSW_9_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_90X_upgrade2023_realistic_v9_D4TPU200r3-v1/00000/02E3478F-3D22-E711-80C4-0CC47A4D7654.root'
-#        'file:0EDF6499-AF35-E711-8039-0CC47A7C3428.root',
-        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/0EDF6499-AF35-E711-8039-0CC47A7C3428.root',
-        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/36ED744B-B235-E711-ADE1-0025905A6084.root',
-        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/4436C35F-B235-E711-8F37-0025905A6090.root',
-        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/5A6B4153-AF35-E711-A958-0CC47A745298.root',
-        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/5CF20899-AF35-E711-A952-0025905A60BE.root',
-        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/88C22846-AF35-E711-BC3D-0CC47A7C346E.root'
-
+        '/store/relval/CMSSW_9_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_90X_upgrade2023_realistic_v9_D4TPU200r3-v1/00000/02E3478F-3D22-E711-80C4-0CC47A4D7654.root'
     ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
@@ -47,7 +39,7 @@ process.ana.TestParticleFilter.protonEMin = cms.double(100000)
 process.ana.TestParticleFilter.etaMax = cms.double(3.1)
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("hgcalNtuple-test.root")
+                                   fileName = cms.string("hgcalNtuple.root")
 
                                    )
 

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -35,7 +35,7 @@ process.source = cms.Source("PoolSource",
 
 process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              detector = cms.string("all"),
-                             rawRecHits = cms.bool(False),
+                             rawRecHits = cms.bool(True),
                              readOfficialReco = cms.bool(True),
                              readCaloParticles = cms.bool(False),
                              dEdXWeights = dEdX,
@@ -47,7 +47,7 @@ process.ana.TestParticleFilter.protonEMin = cms.double(100000)
 process.ana.TestParticleFilter.etaMax = cms.double(3.1)
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("hgcalNtuple-pca-clusteringFix-test.root")
+                                   fileName = cms.string("hgcalNtuple-test.root")
 
                                    )
 

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -46,12 +46,12 @@ process.TFileService = cms.Service("TFileService",
 reRunClustering = True
 
 if reRunClustering:
-    process.hgcalLayerClusters.minClusters = cms.uint32(0)
-    process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
-    process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)  # in cm if realSpaceCone is true
-    process.hgcalLayerClusters.dependSensor = cms.bool(True)
-    process.hgcalLayerClusters.ecut = cms.double(3.)  # multiple of sigma noise if dependSensor is true
-    process.hgcalLayerClusters.kappa = cms.double(9.)  # multiple of sigma noise if dependSensor is true
+    #process.hgcalLayerClusters.minClusters = cms.uint32(0)
+    #process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
+    #process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)  # in cm if realSpaceCone is true
+    #process.hgcalLayerClusters.dependSensor = cms.bool(True)
+    #process.hgcalLayerClusters.ecut = cms.double(3.)  # multiple of sigma noise if dependSensor is true
+    #process.hgcalLayerClusters.kappa = cms.double(9.)  # multiple of sigma noise if dependSensor is true
     #process.hgcalLayerClusters.deltac = cms.vdouble(2.,3.,5.) #specify delta c for each subdetector separately
     process.p = cms.Path(process.hgcalLayerClusters+process.ana)
 else:

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -4,24 +4,31 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process("Demo")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D13Reco_cff')
-process.load('Configuration.StandardSequences.MagneticField_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('RecoLocalCalo.HGCalRecProducers.HGCalLocalRecoSequence_cff')
 
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
-
 from FastSimulation.Event.ParticleFilter_cfi import *
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights as dEdX
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_9_1_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_91X_upgrade2023_realistic_v1_D13PU200-v2/10000/04A22787-5E31-E711-A724-0025905A6090.root'
+        #        '/store/relval/CMSSW_9_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_90X_upgrade2023_realistic_v9_D4TPU200r3-v1/00000/02E3478F-3D22-E711-80C4-0CC47A4D7654.root'
+#        'file:0EDF6499-AF35-E711-8039-0CC47A7C3428.root',
+        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/0EDF6499-AF35-E711-8039-0CC47A7C3428.root',
+        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/36ED744B-B235-E711-ADE1-0025905A6084.root',
+        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/4436C35F-B235-E711-8F37-0025905A6090.root',
+        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/5A6B4153-AF35-E711-A958-0CC47A745298.root',
+        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/5CF20899-AF35-E711-A952-0025905A60BE.root',
+        '/store/relval/CMSSW_9_1_0_pre3/RelValDoubleElectronPt15Eta17_27/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D13noSmear-v1/10000/88C22846-AF35-E711-BC3D-0CC47A7C346E.root'
+
     ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
@@ -31,6 +38,7 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              rawRecHits = cms.bool(True),
                              readOfficialReco = cms.bool(True),
                              readCaloParticles = cms.bool(False),
+                             dEdXWeights = dEdX,
                              layerClusterPtThreshold = cms.double(-1),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
 )
@@ -39,19 +47,19 @@ process.ana.TestParticleFilter.protonEMin = cms.double(100000)
 process.ana.TestParticleFilter.etaMax = cms.double(3.1)
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("hgcalNtuple.root")
+                                   fileName = cms.string("hgcalNtuple-pca.root")
 
                                    )
 
 reRunClustering = True
 
 if reRunClustering:
-    # process.hgcalLayerClusters.minClusters = cms.uint32(0)
-    # process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
-    # process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)  # in cm if realSpaceCone is true
-    # process.hgcalLayerClusters.dependSensor = cms.bool(True)
-    # process.hgcalLayerClusters.ecut = cms.double(3.)  # multiple of sigma noise if dependSensor is true
-    # process.hgcalLayerClusters.kappa = cms.double(9.)  # multiple of sigma noise if dependSensor is true
+    process.hgcalLayerClusters.minClusters = cms.uint32(0)
+    process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
+    process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)  # in cm if realSpaceCone is true
+    process.hgcalLayerClusters.dependSensor = cms.bool(True)
+    process.hgcalLayerClusters.ecut = cms.double(3.)  # multiple of sigma noise if dependSensor is true
+    process.hgcalLayerClusters.kappa = cms.double(9.)  # multiple of sigma noise if dependSensor is true
     #process.hgcalLayerClusters.deltac = cms.vdouble(2.,3.,5.) #specify delta c for each subdetector separately
     process.p = cms.Path(process.hgcalLayerClusters+process.ana)
 else:

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -20,7 +20,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_9_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_90X_upgrade2023_realistic_v9_D4TPU200r3-v1/00000/02E3478F-3D22-E711-80C4-0CC47A4D7654.root'
+        '/store/relval/CMSSW_9_1_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_91X_upgrade2023_realistic_v1_D13PU200-v2/10000/04A22787-5E31-E711-A724-0025905A6090.root'
     ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )


### PR DESCRIPTION
Fixed bugs : 1) reachedEE which had been turned into an int (1=barrel, 2=endcaps)  2) the extrapolated positions were no longer stored. 
Added features: implementation of PCA analysis to compute the position and the axis of the shower. Added some multicluster observables: number of layers, first layer, last layer, sigma_uu and vv which are the equivalent of sigma-eta-eta and sigma-phi-phi but in centimeters. 
In the PCA computation, a weight based on the mip value is introduced, which required modifying the config file.

Apologies for the differences in the indentation introduced by my editor that I have tried to undo as much as possible.