### PR TITLE
update code to cope with old and new geometry, also update HGCalMulti…

### DIFF
--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -1525,7 +1525,7 @@ void HGCalAnalysis::analyze(const edm::Event &iEvent, const edm::EventSetup &iSe
       float energyFH = 0.;
       float energyBH = 0.;
       for (reco::CaloCluster_iterator cl = sc->clustersBegin(); cl != sc->clustersEnd(); ++cl) {
-        if (DetId::Forward == (*cl)->seed().det()) {
+        if ((*cl)->seed().det() == DetId::Forward || (*cl)->seed().det() == DetId::HGCalEE || (*cl)->seed().det() == DetId::HGCalHSi) {
           if (false)
             std::cout << "SuperCluster Key: " << sc.key() << " own CaloCluster Key: " << cl->key();
           if (electrons_ValueMapClusters.contains(cl->id())) {
@@ -1787,7 +1787,7 @@ int HGCalAnalysis::fillLayerCluster(const edm::Ptr<reco::CaloCluster> &layerClus
 
     if (storePCAvariables_) {
       double thickness =
-          (DetId::Forward == DetId(rh_detid).det()) ? recHitTools_.getSiThickness(rh_detid) : -1;
+          (rh_detid.det() == DetId::Forward || rh_detid.det() == DetId::HGCalEE || rh_detid.det() == DetId::HGCalHSi) ? recHitTools_.getSiThickness(rh_detid) : -1;
       double mip = dEdXWeights_[layer] * 0.001;  // convert in GeV
       if (thickness > 99. && thickness < 101)
         mip *= invThicknessCorrection_[0];
@@ -1875,7 +1875,7 @@ void HGCalAnalysis::fillRecHit(const DetId &detid, const float &fraction, const 
       (DetId::Forward == DetId(detid).det() ? recHitTools_.getCell(detid)
                                             : std::numeric_limits<unsigned int>::max());
   const double cellThickness =
-      (DetId::Forward == DetId(detid).det() ? recHitTools_.getSiThickness(detid)
+      ((detid.det() == DetId::Forward || detid.det() == DetId::HGCalEE || detid.det() == DetId::HGCalHSi) ? recHitTools_.getSiThickness(detid)
                                             : std::numeric_limits<std::float_t>::max());
   const bool isHalfCell = recHitTools_.isHalfCell(detid);
   const double eta = recHitTools_.getEta(position, vz_);
@@ -2009,7 +2009,7 @@ void HGCalAnalysis::doRecomputePCA(const reco::HGCalMultiCluster &cluster, math:
       if (local.Perp2() > radius2) continue;
 
       double thickness =
-          (DetId::Forward == DetId(rh_detid).det()) ? recHitTools_.getSiThickness(rh_detid) : -1;
+          (rh_detid.det() == DetId::Forward || rh_detid.det() == DetId::HGCalEE || rh_detid.det() == DetId::HGCalHSi) ? recHitTools_.getSiThickness(rh_detid) : -1;
       double mip = dEdXWeights_[layer] * 0.001;  // convert in GeV
       if (thickness > 99. && thickness < 101)
         mip *= invThicknessCorrection_[0];

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -193,6 +193,7 @@ class HGCalAnalysis : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one:
   double layerClusterPtThreshold_;
   double propagationPtThreshold_;
   std::string detector_;
+  std::string inputTag_HGCalMultiCluster_;
   bool rawRecHits_;
 
   // ----------member data ---------------------------
@@ -497,6 +498,7 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet &iConfig)
       layerClusterPtThreshold_(iConfig.getParameter<double>("layerClusterPtThreshold")),
       propagationPtThreshold_(iConfig.getUntrackedParameter<double>("propagationPtThreshold", 3.0)),
       detector_(iConfig.getParameter<std::string>("detector")),
+      inputTag_HGCalMultiCluster_(iConfig.getParameter<std::string>("inputTag_HGCalMultiCluster")),
       rawRecHits_(iConfig.getParameter<bool>("rawRecHits")),
       particleFilter_(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
       dEdXWeights_(iConfig.getParameter<std::vector<double>>("dEdXWeights")),
@@ -541,7 +543,7 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet &iConfig)
   pfClustersFromMultiCl_ =
       consumes<std::vector<reco::PFCluster>>(edm::InputTag("particleFlowClusterHGCalFromMultiCl"));
   multiClusters_ =
-      consumes<std::vector<reco::HGCalMultiCluster>>(edm::InputTag("hgcalMultiClusters"));
+      consumes<std::vector<reco::HGCalMultiCluster>>(edm::InputTag(inputTag_HGCalMultiCluster_));
   tracks_ = consumes<std::vector<reco::Track>>(edm::InputTag("generalTracks"));
   electrons_ =
       consumes<std::vector<reco::GsfElectron>>(edm::InputTag("ecalDrivenGsfElectronsFromMultiCl"));

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -9,7 +9,11 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load('RecoLocalCalo.HGCalRecProducers.HGCalLocalRecoSequence_cff')
+try:
+    process.load('RecoLocalCalo.HGCalRecProducers.HGCalLocalRecoSequence_cff')
+except Exception: # ConfigFileReadError in case config does not exist
+    process.load('SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi')
+    process.load('RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 from FastSimulation.Event.ParticleFilter_cfi import *
@@ -27,6 +31,7 @@ process.source = cms.Source("PoolSource",
 
 process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              detector = cms.string("all"),
+                             inputTag_HGCalMultiCluster = cms.string("hgcalLayerClusters"),
                              rawRecHits = cms.bool(True),
                              readCaloParticles = cms.bool(True),
                              storeGenParticleOrigin = cms.bool(True),

--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ scram b -j4
 ```
 
 The input file needs to be step3 (i.e. RECO). Example configs are provided in [HGCalAnalysis/test](HGCalAnalysis/test).
+
+Mind that depending on your RECO input file, you need to set `inputTag_HGCalMultiCluster` in the config part for the `EDAnalyzer` of `HGCalAnalysis` (i.e. the ntupliser) to either `hgcalMultiClusters` (newer releases) or `hgcalLayerClusters` (older releases).


### PR DESCRIPTION
…Cluster to InputTag hgcalMultiClusters

Addresses issues when running on D28/30 geometry.

Changes proposed in this pull-request:

- allow running with both versions of the geometry

To be done:

- Code runs fine, but several printouts `RecHit already filled for different layer cluster` when running with D28 - could be due to issues with the geometry itself or _sharing_ being enabled in the clustering.
