### PR TITLE
Got rid of hard-coded values for reachedEE

### DIFF
--- a/Definitions.md
+++ b/Definitions.md
@@ -4,7 +4,7 @@
 | ------------- | ------------- | ----- | ----- |
 | event/run/lumi | - | - | general event info |
 | vtx | `g4SimHits` | `std::vector<SimVertex>` | primary vertex position |
-| genpart | `g4SimHits` | `std::vector<SimTrack>` | truth level tracks/particles |
+| genpart | `g4SimHits` | `std::vector<SimTrack>` | truth level tracks/particles and information related to their extrapolation towards HGCAL. In particular reachedEE==2 indicates that the particles reached HGCAL while reachedEE==1 is for barrel and reachedEE==0 is for the other cases |
 | simcluster | `mix:MergedCaloTruth` | `std::vector<SimCluster>` | Geant particle and its associated hits (DetIds) in the HGCal |
 | pfcluster | `particleFlowClusterHGCal` | `std::vector<reco::PFCluster>` | mapping of the SimCluster DetIds to the reconstructed hits |
 | cluster2d | `hgcalLayerClusters` | `reco::CaloClusterCollection` | reconstructed layer (2D) clusters - those that are associated to a multicluster have `cluster2d_multicluster >= 0`, which is the index of the `multiclus` in the ntuple |

--- a/Definitions.md
+++ b/Definitions.md
@@ -4,7 +4,7 @@
 | ------------- | ------------- | ----- | ----- |
 | event/run/lumi | - | - | general event info |
 | vtx | `g4SimHits` | `std::vector<SimVertex>` | primary vertex position |
-| genpart | `g4SimHits` | `std::vector<SimTrack>` | truth level tracks/particles and information related to their extrapolation towards HGCAL. In particular reachedEE==2 indicates that the particles reached HGCAL while reachedEE==1 is for barrel and reachedEE==0 is for the other cases |
+| genpart | `g4SimHits` | `std::vector<SimTrack>` | truth level tracks/particles and information related to their extrapolation towards HGCAL. In particular `reachedEE==2` indicates that the particles reached HGCAL while `reachedEE==1` is for barrel calorimeter and `reachedEE==0` is for the other cases |
 | simcluster | `mix:MergedCaloTruth` | `std::vector<SimCluster>` | Geant particle and its associated hits (DetIds) in the HGCal |
 | pfcluster | `particleFlowClusterHGCal` | `std::vector<reco::PFCluster>` | mapping of the SimCluster DetIds to the reconstructed hits |
 | cluster2d | `hgcalLayerClusters` | `reco::CaloClusterCollection` | reconstructed layer (2D) clusters - those that are associated to a multicluster have `cluster2d_multicluster >= 0`, which is the index of the `multiclus` in the ntuple |

--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -150,6 +150,10 @@ class HGCalAnalysis : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one:
   typedef ROOT::Math::Transform3DPJ Transform3D;
   typedef ROOT::Math::Transform3DPJ::Point Point;
 
+  // approximative geometrical values
+  static constexpr float hgcalOuterRadius_ = 160.;
+  static constexpr float hgcalInnerRadius_ = 25.;
+
   HGCalAnalysis();
   explicit HGCalAnalysis(const edm::ParameterSet &);
   ~HGCalAnalysis();
@@ -473,8 +477,7 @@ class HGCalAnalysis : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one:
   std::vector<float> layerPositions_;
   std::vector<double> dEdXWeights_;
   std::vector<double> invThicknessCorrection_;
-  float hgcalOuterRadius_;
-  float hgcalInnerRadius_;
+
 
   // and also the magnetic field
   MagneticField const *aField_;
@@ -501,8 +504,6 @@ HGCalAnalysis::HGCalAnalysis(const edm::ParameterSet &iConfig)
       particleFilter_(iConfig.getParameter<edm::ParameterSet>("TestParticleFilter")),
       dEdXWeights_(iConfig.getParameter<std::vector<double>>("dEdXWeights")),
       invThicknessCorrection_({1. / 1.132, 1. / 1.092, 1. / 1.084}),
-      hgcalOuterRadius_(iConfig.getParameter<double>("hgcalOuterRadius")),
-      hgcalInnerRadius_(iConfig.getParameter<double>("hgcalInnerRadius")),
       pca_(new TPrincipal(3, "D")) {
   // now do what ever initialization is needed
   mySimEvent_ = new FSimEvent(particleFilter_);

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -39,6 +39,8 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              includeHaloPCA = cms.bool(True),
                              dEdXWeights = dEdX,
                              layerClusterPtThreshold = cms.double(-1),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
+                             hgcalOuterRadius = cms.double(160.),
+                             hgcalInnerRadius = cms.double(25.),
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
 )
 

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -15,7 +15,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 from FastSimulation.Event.ParticleFilter_cfi import *
 from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights as dEdX
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
@@ -39,8 +39,6 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              includeHaloPCA = cms.bool(True),
                              dEdXWeights = dEdX,
                              layerClusterPtThreshold = cms.double(-1),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
-                             hgcalOuterRadius = cms.double(160.),
-                             hgcalInnerRadius = cms.double(25.),
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
 )
 

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -15,7 +15,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 from FastSimulation.Event.ParticleFilter_cfi import *
 from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights as dEdX
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use


### PR DESCRIPTION
Changes proposed in this pull-request:

- added a few explanations on the meaning of the reachedEE variable
- removed the hard-coded values needed in the reachedEE computation (hgcal inner and outer radii). Used constexpr instead. Additionally, retrieve the number of layers from RecHitTools

