### PR TITLE
Update setup instruction for 10_3_X and point to old releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # reco-ntuples
+
 Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-This version is based on >= CMSSW_10_2_0_pre1, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_2_X` versions available to profit from bugfixes.
+This version is based on >= CMSSW_10_3_0_pre5, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_3_X` versions available to profit from bugfixes.
 
-```
-cmsrel CMSSW_10_2_0_pre1
-cd CMSSW_10_2_0_pre1/src
+```shell
+cmsrel CMSSW_10_3_0_pre5
+cd CMSSW_10_3_0_pre5/src
 cmsenv
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 cd RecoNtuples
@@ -19,3 +20,5 @@ scram b -j4
 The input file needs to be step3 (i.e. RECO). Example configs are provided in [HGCalAnalysis/test](HGCalAnalysis/test).
 
 Mind that depending on your RECO input file, you need to set `inputTag_HGCalMultiCluster` in the config part for the `EDAnalyzer` of `HGCalAnalysis` (i.e. the ntupliser) to either `hgcalMultiClusters` (newer releases) or `hgcalLayerClusters` (older releases).
+
+For older versions, please check the [releases tab](https://github.com/CMS-HGCAL/reco-ntuples/releases).


### PR DESCRIPTION
Addresses #66

Changes proposed in this pull-request:

- update setup documentation
- point to old releases

I checked that the new function was introduced in [CMSSW_10_3_0_pre5](https://github.com/cms-sw/cmssw/releases/tag/CMSSW_10_3_0_pre5) with [this commit](https://github.com/cms-sw/cmssw/commit/ebd8f4066dab207397afb80b31916163e33689f4).