### PR TITLE
Update ntuplizer and sample to the latest pre-release

### DIFF
--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -24,7 +24,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 process.source = cms.Source("PoolSource",
     # replace 'step3.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        'file:step3.root'
+        '/store/cmst3/group/hgcal/CMG_studies/validation/step3.root'
     ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )

--- a/HGCalAnalysis/test/exampleConfig.py
+++ b/HGCalAnalysis/test/exampleConfig.py
@@ -4,7 +4,7 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process("Demo")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D35Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -17,21 +17,21 @@ except Exception: # ConfigFileReadError in case config does not exist
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 from FastSimulation.Event.ParticleFilter_cfi import *
-from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights as dEdX
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
 process.source = cms.Source("PoolSource",
-    # replace 'myfile.root' with the source file you want to use
+    # replace 'step3.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        '/store/mc/PhaseIITDRFall17DR/SingleGammaPt100Eta1p6_2p8/GEN-SIM-RECO/noPUFEVT_93X_upgrade2023_realistic_v2-v1/90000/02F2B8A2-44AA-E711-BD55-7845C4FC38ED.root'
+        'file:step3.root'
     ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
 
 process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              detector = cms.string("all"),
-                             inputTag_HGCalMultiCluster = cms.string("hgcalLayerClusters"),
+                             inputTag_HGCalMultiCluster = cms.string("hgcalMultiClusters"),
                              rawRecHits = cms.bool(True),
                              readCaloParticles = cms.bool(True),
                              storeGenParticleOrigin = cms.bool(True),
@@ -42,7 +42,7 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              readGenParticles = cms.bool(True),
                              recomputePCA = cms.bool(False),
                              includeHaloPCA = cms.bool(True),
-                             dEdXWeights = dEdX,
+                             dEdXWeights = dEdX.weights,
                              layerClusterPtThreshold = cms.double(-1),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
 )
@@ -54,8 +54,8 @@ process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string("hgcalNtuple.root")
 
                                    )
-
-reRunClustering = True
+# The clustering algorithm has been changed
+reRunClustering = False
 
 if reRunClustering:
     #process.hgcalLayerClusters.minClusters = cms.uint32(0)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-This version is based on >= CMSSW_10_3_0_pre5, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_3_X` versions available to profit from bugfixes.
+This version is based on >= CMSSW_10_6_0_pre2, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_3_X` versions available to profit from bugfixes.
 
 ```shell
-cmsrel CMSSW_10_3_0_pre5
-cd CMSSW_10_3_0_pre5/src
+cmsrel CMSSW_10_6_0_pre2
+cd CMSSW_10_6_0_pre2/src
 cmsenv
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 cd RecoNtuples

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-This version is based on >= CMSSW_10_6_0_pre2, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_3_X` versions available to profit from bugfixes.
+This version is based on >= CMSSW_10_6_0_pre2, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_6_X` versions available to profit from bugfixes.
 
 ```shell
 cmsrel CMSSW_10_6_0_pre2


### PR DESCRIPTION
This PR addresses the following problems:

- the structure of dEdx weights has changed in CMSSW
- Geometry is now D35
- the default clustering algorithm is changing and reclustering by default will not be useful until the clustering algo is updated
- The readme is updated

@rovere @malgeri 