### PR TITLE
updating ntuplizer to latest CMSSW

### DIFF
--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -36,12 +36,11 @@
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-#include "FastSimulation/BaseParticlePropagator/interface/BaseParticlePropagator.h"
+#include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
 #include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
 #include "FastSimulation/Event/interface/FSimEvent.h"
 #include "FastSimulation/Event/interface/FSimTrack.h"
 #include "FastSimulation/Event/interface/FSimVertex.h"
-#include "FastSimulation/Particle/interface/ParticleTable.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h"
@@ -1062,7 +1061,6 @@ void HGCalAnalysis::analyze(const edm::Event &iEvent, const edm::EventSetup &iSe
 
   clearVariables();
 
-  ParticleTable::Sentry ptable(mySimEvent_->theTable());
   recHitTools_.getEventSetup(iSetup);
 
   Handle<HGCRecHitCollection> recHitHandleEE;

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-This version is based on >= `CMSSW_10_6_X_2019-03-27-2300`, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_6_X` versions available to profit from bugfixes.
+This version is based on >= `CMSSW_10_6_0_pre3`, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_6_X` versions available to profit from bugfixes.
 
 ```shell
-cmsrel CMSSW_10_6_X_2019-03-27-2300
-cd CMSSW_10_6_X_2019-03-27-2300/src
+cmsrel CMSSW_10_6_0_pre3
+cd CMSSW_10_6_0_pre3/src
 cmsenv
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 cd RecoNtuples

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Home of the Ntuplizer for the HGCAL reconstruction software studies
 
 Ntuple content definitions can be found at [Definitions.md](Definitions.md).
 
-This version is based on >= CMSSW_10_6_0_pre2, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_6_X` versions available to profit from bugfixes.
+This version is based on >= `CMSSW_10_6_X_2019-03-27-2300`, instructions below should provide you with the version for the TDR sample production. Please check if there are later `CMSSW_10_6_X` versions available to profit from bugfixes.
 
 ```shell
-cmsrel CMSSW_10_6_0_pre2
-cd CMSSW_10_6_0_pre2/src
+cmsrel CMSSW_10_6_X_2019-03-27-2300
+cd CMSSW_10_6_X_2019-03-27-2300/src
 cmsenv
 git clone git@github.com:CMS-HGCAL/reco-ntuples.git RecoNtuples
 cd RecoNtuples


### PR DESCRIPTION
Changes were made in FastSim in CMSSW and the ntuplizer does not compile anymore with 10_6_X. 
In the short term I suggest we make a tag with the previous version working with 10_6_0_pre2.
In the long term I suggest we move this to CMSSW, so that who changed fast sim would have modified our ntuplizer as well. 


@rovere @clelange @malgeri 

I will update the readme as soon as pre3 is out