### PR TITLE
Remove RecHit eta and pT vertex corrections

### DIFF
--- a/HGCalAnalysis/plugins/HGCalAnalysis.cc
+++ b/HGCalAnalysis/plugins/HGCalAnalysis.cc
@@ -1909,9 +1909,9 @@ void HGCalAnalysis::fillRecHit(const DetId &detid, const float &fraction, const 
       ((detid.det() == DetId::Forward || detid.det() == DetId::HGCalEE || detid.det() == DetId::HGCalHSi) ? recHitTools_.getSiThickness(detid)
                                             : std::numeric_limits<std::float_t>::max());
   const bool isHalfCell = recHitTools_.isHalfCell(detid);
-  const double eta = recHitTools_.getEta(position, vz_);
+  const double eta = recHitTools_.getEta(position);
   const double phi = recHitTools_.getPhi(position);
-  const double pt = recHitTools_.getPt(position, hit->energy(), vz_);
+  const double pt = recHitTools_.getPt(position, hit->energy());
 
   // fill the vectors
   rechit_eta_.push_back(eta);


### PR DESCRIPTION
Changes proposed in this pull-request:

- Remove vertex z position in calculation of rec hit pT and eta.

Eta of a rec hit should be absolute and not depend on the vertex position. For the pT calculation, the vertex position is only used to internally compute eta again (see [here](https://github.com/cms-sw/cmssw/blob/c3add817cdd8849edf51b6278eeeaad3d7aba618/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc#L434-L438)). In both methods, the default value is `0` which is the desired value.